### PR TITLE
fix the lock unresolvable bug.

### DIFF
--- a/tikv/mvcc.go
+++ b/tikv/mvcc.go
@@ -31,10 +31,10 @@ func NewMVCCStore(db *badger.DB) *MVCCStore {
 	return store
 }
 
-func (store *MVCCStore) Get(key []byte, startTS uint64) ([]byte, error) {
+func (store *MVCCStore) Get(regCtx *regionCtx, key []byte, startTS uint64) ([]byte, error) {
 	var result valueResult
 	err := store.db.View(func(txn *badger.Txn) error {
-		g := &getter{txn: txn}
+		g := &getter{txn: txn, regCtx: regCtx}
 		defer g.close()
 		result = g.mvGet(key, startTS)
 		return nil
@@ -58,8 +58,9 @@ type valueResult struct {
 }
 
 type getter struct {
-	txn  *badger.Txn
-	iter *badger.Iterator
+	txn    *badger.Txn
+	regCtx *regionCtx
+	iter   *badger.Iterator
 }
 
 func (g *getter) mvGet(key []byte, startTS uint64) (result valueResult) {
@@ -78,7 +79,7 @@ func (g *getter) mvGet(key []byte, startTS uint64) (result valueResult) {
 		return
 	}
 	if mixed.hasLock() {
-		result.err = checkLock(mixed.lock, key, startTS)
+		result.err = checkLock(g.regCtx, mixed.lock, key, startTS)
 		if result.err != nil {
 			return
 		}
@@ -117,11 +118,14 @@ func (g *getter) close() {
 	}
 }
 
-func checkLock(lock mvccLock, key []byte, startTS uint64) error {
+func checkLock(regCtx *regionCtx, lock mvccLock, key []byte, startTS uint64) error {
 	lockVisible := lock.startTS < startTS
 	isWriteLock := lock.op == kvrpcpb.Op_Put || lock.op == kvrpcpb.Op_Del
 	isPrimaryGet := lock.startTS == lockVer && bytes.Equal(lock.primary, key)
 	if lockVisible && isWriteLock && !isPrimaryGet {
+		if extractPhysical(lock.startTS)+lock.ttl < extractPhysical(startTS) {
+			regCtx.addTxnKey(startTS, key)
+		}
 		return &ErrLocked{
 			Key:     key,
 			StartTS: lock.startTS,
@@ -132,10 +136,14 @@ func checkLock(lock mvccLock, key []byte, startTS uint64) error {
 	return nil
 }
 
-func (store *MVCCStore) BatchGet(keys [][]byte, startTS uint64) []Pair {
+func extractPhysical(ts uint64) uint64 {
+	return ts >> 18
+}
+
+func (store *MVCCStore) BatchGet(regCtx *regionCtx, keys [][]byte, startTS uint64) []Pair {
 	var pairs []Pair
 	err := store.db.View(func(txn *badger.Txn) error {
-		g := &getter{txn: txn}
+		g := &getter{txn: txn, regCtx: regCtx}
 		defer g.close()
 		for _, key := range keys {
 			result := g.mvGet(key, startTS)
@@ -162,7 +170,7 @@ func (store *MVCCStore) Prewrite(regCtx *regionCtx, mutations []*kvrpcpb.Mutatio
 	var anyError bool
 	err := store.db.View(func(txn *badger.Txn) error {
 		for _, m := range mutations {
-			err1 := batch.prewriteMutation(txn, m, primary, startTS, ttl)
+			err1 := batch.prewriteMutation(regCtx, txn, m, primary, startTS, ttl)
 			if err1 != nil {
 				anyError = true
 			}
@@ -190,7 +198,7 @@ func (store *MVCCStore) Prewrite(regCtx *regionCtx, mutations []*kvrpcpb.Mutatio
 
 const lockVer uint64 = math.MaxUint64
 
-func (batch *writeBatch) prewriteMutation(txn *badger.Txn, mutation *kvrpcpb.Mutation, primary []byte, startTS uint64, ttl uint64) error {
+func (batch *writeBatch) prewriteMutation(regCtx *regionCtx, txn *badger.Txn, mutation *kvrpcpb.Mutation, primary []byte, startTS uint64, ttl uint64) error {
 	mvKey := codec.EncodeBytes(nil, mutation.Key)
 	item, err := txn.Get(mvKey)
 	if err != nil && err != badger.ErrKeyNotFound {
@@ -206,6 +214,9 @@ func (batch *writeBatch) prewriteMutation(txn *badger.Txn, mutation *kvrpcpb.Mut
 			lock := mixed.lock
 			if lock.op != kvrpcpb.Op_Rollback {
 				if lock.startTS != startTS {
+					if extractPhysical(lock.startTS)+lock.ttl < extractPhysical(startTS) {
+						regCtx.addTxnKey(lock.startTS, mutation.Key)
+					}
 					return ErrRetryable("key is locked, try again later")
 				}
 				// Same ts, no need to overwrite.
@@ -445,7 +456,7 @@ func (batch *writeBatch) rollbackKey(txn *badger.Txn, key []byte, startTS uint64
 	return nil
 }
 
-func (store *MVCCStore) Scan(startKey, endKey []byte, limit int, startTS uint64) []Pair {
+func (store *MVCCStore) Scan(regCtx *regionCtx, startKey, endKey []byte, limit int, startTS uint64) []Pair {
 	var pairs []Pair
 	err := store.db.View(func(txn *badger.Txn) error {
 		iter := newIterator(txn)
@@ -467,7 +478,7 @@ func (store *MVCCStore) Scan(startKey, endKey []byte, limit int, startTS uint64)
 				return errors.Trace(err1)
 			}
 			if mixed.hasLock() {
-				err1 = checkLock(mixed.lock, rawKey, startTS)
+				err1 = checkLock(regCtx, mixed.lock, rawKey, startTS)
 				if err1 != nil {
 					return errors.Trace(err1)
 				}
@@ -515,7 +526,7 @@ func isVisibleKey(mvKey []byte, startTS uint64) bool {
 }
 
 // ReverseScan implements the MVCCStore interface. The search range is [startKey, endKey).
-func (store *MVCCStore) ReverseScan(startKey, endKey []byte, limit int, startTS uint64) []Pair {
+func (store *MVCCStore) ReverseScan(regCtx *regionCtx, startKey, endKey []byte, limit int, startTS uint64) []Pair {
 	var pairs []Pair
 	err := store.db.View(func(txn *badger.Txn) error {
 		var opts badger.IteratorOptions
@@ -540,7 +551,7 @@ func (store *MVCCStore) ReverseScan(startKey, endKey []byte, limit int, startTS 
 				return errors.Trace(err1)
 			}
 			if mixed.hasLock() {
-				err1 = checkLock(mixed.lock, rawKey, startTS)
+				err1 = checkLock(regCtx, mixed.lock, rawKey, startTS)
 				if err1 != nil {
 					return errors.Trace(err1)
 				}

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -160,6 +160,18 @@ func (ri *regionCtx) addTxnKeys(startTS uint64, keys [][]byte) {
 	ri.txnKeysMap[startTS] = keys
 }
 
+func (ri *regionCtx) addTxnKey(startTS uint64, key []byte) {
+	ri.txnKeysMu.Lock()
+	defer ri.txnKeysMu.Unlock()
+	keys := ri.txnKeysMap[startTS]
+	for _, k := range keys {
+		if bytes.Equal(k, key) {
+			return
+		}
+	}
+	ri.txnKeysMap[startTS] = append(keys, key)
+}
+
 func (ri *regionCtx) removeTxnKeys(startTS uint64) {
 	ri.txnKeysMu.Lock()
 	defer ri.txnKeysMu.Unlock()

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -45,7 +45,7 @@ func (svr *Server) KvGet(ctx context.Context, req *kvrpcpb.GetRequest) (*kvrpcpb
 		return &kvrpcpb.GetResponse{RegionError: regErr}, nil
 	}
 	regCtx.assertContainsKey(req.Key)
-	val, err := svr.mvccStore.Get(req.Key, req.GetVersion())
+	val, err := svr.mvccStore.Get(regCtx, req.Key, req.GetVersion())
 	if err != nil {
 		return &kvrpcpb.GetResponse{
 			Error: convertToKeyError(err),
@@ -65,7 +65,7 @@ func (svr *Server) KvScan(ctx context.Context, req *kvrpcpb.ScanRequest) (*kvrpc
 	if !isMvccRegion(regCtx) {
 		return &kvrpcpb.ScanResponse{}, nil
 	}
-	pairs := svr.mvccStore.Scan(req.GetStartKey(), regCtx.rawEndKey(), int(req.GetLimit()), req.GetVersion())
+	pairs := svr.mvccStore.Scan(regCtx, req.GetStartKey(), regCtx.rawEndKey(), int(req.GetLimit()), req.GetVersion())
 	return &kvrpcpb.ScanResponse{
 		Pairs: convertToPbPairs(pairs),
 	}, nil
@@ -135,7 +135,7 @@ func (svr *Server) KvBatchGet(ctx context.Context, req *kvrpcpb.BatchGetRequest)
 	for _, k := range req.Keys {
 		regCtx.assertContainsKey(k)
 	}
-	pairs := svr.mvccStore.BatchGet(req.Keys, req.GetVersion())
+	pairs := svr.mvccStore.BatchGet(regCtx, req.Keys, req.GetVersion())
 	return &kvrpcpb.BatchGetResponse{
 		Pairs: convertToPbPairs(pairs),
 	}, nil


### PR DESCRIPTION
The `txnKeysMap` is only kept in memory, it can be lost.
So when a request meets a lock, we add it to the `txnKeysMap`, the lock will be able to resolve later.