### PR TITLE
fix split bug after removing key encoding

### DIFF
--- a/tikv/server.go
+++ b/tikv/server.go
@@ -376,9 +376,9 @@ func convertToPbPairs(pairs []Pair) []*kvrpcpb.KvPair {
 }
 
 func isMvccRegion(regCtx *regionCtx) bool {
-	if len(regCtx.meta.StartKey) == 0 {
+	if len(regCtx.startKey) == 0 {
 		return false
 	}
-	first := regCtx.meta.StartKey[0]
+	first := regCtx.startKey[0]
 	return first == 't' || first == 'm'
 }


### PR DESCRIPTION
This bug will cause a single region as big as the whole database.
Should use region.startKey instead of region.meta.StartKey in split check.