### PR TITLE
introduce lockstore

### DIFF
--- a/lockstore/arena.go
+++ b/lockstore/arena.go
@@ -1,0 +1,139 @@
+package lockstore
+
+import (
+	"math"
+	"time"
+)
+
+type arenaAddr uint64
+
+const (
+	alignMask                 = 1<<32 - 8 // 29 bit 1 and 3 bit 0.
+	nullBlockOffset           = math.MaxUint32
+	nullArenaAddr   arenaAddr = 0
+
+	// Time waited until we reuse the empty block.
+	// Data corruption can happen under this time sequence.
+	// 1. a reader reads a node.
+	// 2. a writer delete the node, then free the block, put it into the writable queue
+	// 	and this block become the first writable block.
+	// 3. The writer insert another node, overwrite the block we just freed.
+	// 4. The reader reads the key/value of that delete node.
+	// But because the time between 1 and 4 is very short, this is very unlikely to happen but it can happen.
+	// So we wait for a while so the reader can finish reading before we overwrite the empty block.
+	reuseSafeDuration = time.Millisecond * 100
+)
+
+func (addr arenaAddr) blockIdx() int {
+	return int(addr>>32 - 1)
+}
+
+func (addr arenaAddr) blockOffset() uint32 {
+	return uint32(addr)
+}
+
+func newArenaAddr(blockIdx int, blockOffset uint32) arenaAddr {
+	return arenaAddr(uint64(blockIdx+1)<<32 | uint64(blockOffset))
+}
+
+type arena struct {
+	blockSize     int
+	blocks        []*arenaBlock
+	writableQueue []int
+	pendingBlocks []pendingBlock
+}
+
+type pendingBlock struct {
+	blockIdx     int
+	reusableTime time.Time
+}
+
+func newArenaLocator(blockSize int) *arena {
+	return &arena{
+		blockSize:     blockSize,
+		blocks:        []*arenaBlock{newArenaBlock(blockSize)},
+		writableQueue: []int{0},
+	}
+}
+
+func (a *arena) get(addr arenaAddr, size int) []byte {
+	return a.blocks[addr.blockIdx()].get(addr.blockOffset(), size)
+}
+
+func (a *arena) alloc(size int) arenaAddr {
+	for {
+		if len(a.writableQueue) == 0 {
+			if len(a.pendingBlocks) > 0 {
+				pending := a.pendingBlocks[0]
+				if time.Now().After(pending.reusableTime) {
+					a.writableQueue = append(a.writableQueue, pending.blockIdx)
+					a.pendingBlocks = a.pendingBlocks[1:]
+					continue
+				}
+			}
+			return nullArenaAddr
+		}
+		availIdx := a.writableQueue[len(a.writableQueue)-1]
+		block := a.blocks[availIdx]
+		blockOffset := block.alloc(size)
+		if blockOffset != nullBlockOffset {
+			return newArenaAddr(availIdx, blockOffset)
+		}
+		a.writableQueue = a.writableQueue[:len(a.writableQueue)-1]
+	}
+}
+
+// free decrease the arena block reference and makes the block reusable.
+// We don't know if there is concurrent reader who may reference the deleted entry.
+// So we must make sure the old data is not referenced for long time, and we only overwrite
+// it after a safe amount of time.
+func (a *arena) free(addr arenaAddr) {
+	arena := a.blocks[addr.blockIdx()]
+	arena.ref--
+	// No reference, the arenaBlock can be reused.
+	if arena.ref == 0 && arena.length > len(arena.buf) {
+		a.pendingBlocks = append(a.pendingBlocks, pendingBlock{
+			blockIdx:     addr.blockIdx(),
+			reusableTime: time.Now().Add(reuseSafeDuration),
+		})
+		arena.length = 0
+	}
+}
+
+func (a *arena) grow() *arena {
+	newLoc := new(arena)
+	newLoc.blockSize = a.blockSize
+	newLoc.blocks = make([]*arenaBlock, 0, len(a.blocks)+1)
+	newLoc.blocks = append(newLoc.blocks, a.blocks...)
+	availIdx := len(newLoc.blocks)
+	newLoc.blocks = append(newLoc.blocks, newArenaBlock(a.blockSize))
+	newLoc.writableQueue = append(newLoc.writableQueue, availIdx)
+	return newLoc
+}
+
+type arenaBlock struct {
+	buf    []byte
+	ref    uint64
+	length int
+}
+
+func newArenaBlock(blockSize int) *arenaBlock {
+	return &arenaBlock{
+		buf: make([]byte, blockSize),
+	}
+}
+
+func (a *arenaBlock) get(offset uint32, size int) []byte {
+	return a.buf[offset : offset+uint32(size)]
+}
+
+func (a *arenaBlock) alloc(size int) uint32 {
+	// The returned addr should be aligned in 8 bytes.
+	offset := (a.length + 7) & alignMask
+	a.length = offset + size
+	if a.length > len(a.buf) {
+		return nullBlockOffset
+	}
+	a.ref++
+	return uint32(offset)
+}

--- a/lockstore/iterator.go
+++ b/lockstore/iterator.go
@@ -1,0 +1,69 @@
+package lockstore
+
+// Iterator iterates the entries in the LockStore.
+type Iterator struct {
+	ls  *LockStore
+	key []byte
+	val []byte
+}
+
+// NewIterator returns a new Iterator for the lock store.
+func (ls *LockStore) NewIterator() *Iterator {
+	return &Iterator{
+		ls: ls,
+	}
+}
+
+// Valid returns true iff the iterator is positioned at a valid node.
+func (it *Iterator) Valid() bool { return len(it.key) != 0 }
+
+// Key returns the key at the current position.
+func (it *Iterator) Key() []byte {
+	return it.key
+}
+
+// Value returns value.
+func (it *Iterator) Value() []byte {
+	return it.val
+}
+
+// Next moves the iterator to the next entry.
+func (it *Iterator) Next() {
+	e, _ := it.ls.findGreater(it.key, false)
+	it.setKeyValue(e)
+}
+
+// Prev moves the iterator to the previous entry.
+func (it *Iterator) Prev() {
+	e, _ := it.ls.findLess(it.key, false) // find <. No equality allowed.
+	it.setKeyValue(e)
+}
+
+// Seek locates the iterator to the first entry with a key >= seekKey.
+func (it *Iterator) Seek(seekKey []byte) {
+	e, _ := it.ls.findGreater(seekKey, true) // find >=.
+	it.setKeyValue(e)
+}
+
+// SeekForPrev locates the iterator to the last entry with key <= target.
+func (it *Iterator) SeekForPrev(target []byte) {
+	e, _ := it.ls.findLess(target, true) // find <=.
+	it.setKeyValue(e)
+}
+
+// SeekToFirst locates the iterator to the first entry.
+func (it *Iterator) SeekToFirst() {
+	e := it.ls.getNext(it.ls.head, 0)
+	it.setKeyValue(e)
+}
+
+// SeekToLast locates the iterator to the last entry.
+func (it *Iterator) SeekToLast() {
+	e := it.ls.findLast()
+	it.setKeyValue(e)
+}
+
+func (it *Iterator) setKeyValue(e entry) {
+	it.key = append(it.key[:0], e.key...)
+	it.val = append(it.val[:0], e.getValue(it.ls.getArena())...)
+}

--- a/lockstore/lockstore.go
+++ b/lockstore/lockstore.go
@@ -1,0 +1,331 @@
+package lockstore
+
+import (
+	"bytes"
+	"math"
+	"math/rand"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+// LockStore is a skiplist variant used to store lock.
+// Compares to normal skip list, it only support Insert and Delete operation.
+// and only support single thread write.
+// But it can reuse the memory, so that the memory usage doesn't keep growing.
+type LockStore struct {
+	height   int32 // Current height. 1 <= height <= kMaxHeight.
+	head     *node
+	arenaPtr unsafe.Pointer
+
+	// We only consume 2 bits for a random height call.
+	rand rand.Source64
+}
+
+const (
+	maxHeight     = 16
+	nodeHeadrSize = int(unsafe.Sizeof(nodeHeader{}))
+)
+
+type nodeHeader struct {
+	addr   arenaAddr
+	height uint16
+	keyLen uint16
+	valLen uint32
+}
+
+type node struct {
+	nodeHeader
+	// Height of the nexts.
+
+	nexts [maxHeight]uint64
+}
+
+type entry struct {
+	*node
+	key []byte
+}
+
+func (e *entry) getValue(arena *arena) []byte {
+	if e.node != nil {
+		return e.node.getValue(arena)
+	}
+	return nil
+}
+
+func (n *node) getNextAddr(level int) arenaAddr {
+	return arenaAddr(atomic.LoadUint64(&n.nexts[level]))
+}
+
+func (n *node) setNextAddr(level int, addr arenaAddr) {
+	atomic.StoreUint64(&n.nexts[level], uint64(addr))
+}
+
+func (n *node) entryLen() int {
+	return n.nodeLen() + int(n.keyLen) + int(n.valLen)
+}
+
+func (n *node) nodeLen() int {
+	return int(n.height)*8 + nodeHeadrSize
+}
+
+func (n *node) getKey(a *arena) []byte {
+	nodeLen := n.nodeLen()
+	entryData := a.get(n.addr, nodeLen+int(n.keyLen))
+	return entryData[nodeLen:]
+}
+
+func (n *node) getValue(a *arena) []byte {
+	nodeLenKeyLen := n.nodeLen() + int(n.keyLen)
+	entryData := a.get(n.addr, nodeLenKeyLen+int(n.valLen))
+	return entryData[nodeLenKeyLen:]
+}
+
+func NewLockStore(arenaBlockSize int) *LockStore {
+	return &LockStore{
+		height:   1,
+		head:     new(node),
+		arenaPtr: unsafe.Pointer(newArenaLocator(arenaBlockSize)),
+		rand:     rand.NewSource(time.Now().Unix()).(rand.Source64),
+	}
+}
+
+func (ls *LockStore) getHeight() int {
+	return int(atomic.LoadInt32(&ls.height))
+}
+
+func (ls *LockStore) setHeight(height int) {
+	atomic.StoreInt32(&ls.height, int32(height))
+}
+
+func (ls *LockStore) Get(key, buf []byte) []byte {
+	e, match := ls.findGreater(key, true)
+	if !match {
+		return nil
+	}
+	e.getValue(ls.getArena())
+	return append(buf[:0], e.getValue(ls.getArena())...)
+}
+
+func (ls *LockStore) getNext(n *node, level int) (e entry) {
+	addr := n.getNextAddr(level)
+	if addr == nullArenaAddr {
+		return
+	}
+	arena := ls.getArena()
+	data := arena.get(addr, nodeHeadrSize)
+	e.node = (*node)(unsafe.Pointer(&data[0]))
+	e.key = e.node.getKey(arena)
+	return e
+}
+
+func (ls *LockStore) findGreater(key []byte, allowEqual bool) (entry, bool) {
+	var prev entry
+	prev.node = ls.head
+	level := ls.getHeight() - 1
+	for {
+		next := ls.getNext(prev.node, level)
+		if next.node != nil {
+			cmp := bytes.Compare(next.key, key)
+			if cmp < 0 {
+				// next key is still smaller, keep moving.
+				prev = next
+				continue
+			}
+			if cmp == 0 {
+				// prev.key < key == next.key.
+				if allowEqual {
+					return next, true
+				}
+				next = ls.getNext(next.node, 0)
+				return next, false
+			}
+		}
+		// next is greater than key or next is nil. go to the lower level.
+		if level > 0 {
+			level--
+			continue
+		}
+		return next, false
+	}
+}
+
+func (ls *LockStore) findLess(key []byte, allowEqual bool) (entry, bool) {
+	var prev entry
+	prev.node = ls.head
+	level := ls.getHeight() - 1
+	for {
+		next := ls.getNext(prev.node, level)
+		if next.node != nil {
+			cmp := bytes.Compare(key, next.key)
+			if cmp > 0 {
+				// prev.key < next.key < key. We can continue to move right.
+				prev = next
+				continue
+			}
+			if cmp == 0 && allowEqual {
+				// prev.key < key == next.key.
+				return next, true
+			}
+		}
+		// get closer to the key in the lower level.
+		if level > 0 {
+			level--
+			continue
+		}
+		break
+	}
+	// We are not going to return head.
+	if prev.node == ls.head {
+		return entry{}, false
+	}
+	return prev, false
+}
+
+// findSpliceForLevel returns (outBefore, outAfter) with outBefore.key < key <= outAfter.key.
+// The input "before" tells us where to start looking.
+// If we found a node with the same key, then we return true.
+func (ls *LockStore) findSpliceForLevel(arena *arena, key []byte, before *node, level int) (*node, *node, bool) {
+	for {
+		// Assume before.key < key.
+		nextAddr := before.getNextAddr(level)
+		if nextAddr == nullArenaAddr {
+			return before, nil, false
+		}
+		data := arena.get(nextAddr, nodeHeadrSize)
+		next := (*node)(unsafe.Pointer(&data[0]))
+		nextKey := next.getKey(arena)
+		cmp := bytes.Compare(nextKey, key)
+		if cmp >= 0 {
+			// before.key < key < next.key. We are done for this level.
+			return before, next, cmp == 0
+		}
+		before = next // Keep moving right on this level.
+	}
+}
+
+// findLast returns the last element. If head (empty ls), we return nil. All the find functions
+// will NEVER return the head nodes.
+func (ls *LockStore) findLast() entry {
+	var e entry
+	e.node = ls.head
+	level := ls.getHeight() - 1
+	for {
+		next := ls.getNext(e.node, level)
+		if next.node != nil {
+			e = next
+			continue
+		}
+		if level == 0 {
+			if e.node == ls.head {
+				return entry{}
+			}
+			return e
+		}
+		level--
+	}
+}
+
+func (ls *LockStore) getNode(arena *arena, addr arenaAddr) *node {
+	data := arena.get(addr, nodeHeadrSize)
+	return (*node)(unsafe.Pointer(&data[0]))
+}
+
+// Put inserts the key-value pair.
+func (ls *LockStore) Insert(key []byte, v []byte) bool {
+	arena := ls.getArena()
+	lsHeight := ls.getHeight()
+	var prev [maxHeight + 1]*node
+	var next [maxHeight + 1]*node
+	prev[lsHeight] = ls.head
+	for i := int(lsHeight) - 1; i >= 0; i-- {
+		// Use higher level to speed up for current level.
+		var exists bool
+		prev[i], next[i], exists = ls.findSpliceForLevel(ls.getArena(), key, prev[i+1], i)
+		if exists {
+			// The save key already exists.
+			return false
+		}
+	}
+	height := ls.randomHeight()
+	x := ls.newNode(arena, key, v, height)
+	if height > int(lsHeight) {
+		ls.setHeight(height)
+	}
+
+	// We always insert from the base level and up. After you add a node in base level, we cannot
+	// create a node in the level above because it would have discovered the node in the base level.
+	for i := 0; i < height; i++ {
+		if next[i] != nil {
+			x.nexts[i] = uint64(next[i].addr)
+		} else {
+			x.nexts[i] = uint64(nullArenaAddr)
+		}
+		if prev[i] == nil {
+			prev[i] = ls.head
+		}
+		prev[i].setNextAddr(i, x.addr)
+	}
+	return true
+}
+
+func (ls *LockStore) newNode(arena *arena, key []byte, v []byte, height int) *node {
+	// The base level is already allocated in the node struct.
+	nodeSize := int(nodeHeadrSize) + height*8 + len(key) + len(v)
+	addr := arena.alloc(nodeSize)
+	if addr == nullArenaAddr {
+		arena = arena.grow()
+		ls.setArena(arena)
+		// The new arena block must have enough memory to alloc.
+		addr = arena.alloc(nodeSize)
+	}
+	data := arena.get(addr, nodeSize)
+	node := (*node)(unsafe.Pointer(&data[0]))
+	node.addr = addr
+	node.keyLen = uint16(len(key))
+	node.height = uint16(height)
+	node.valLen = uint32(len(v))
+	copy(data[node.nodeLen():], key)
+	copy(data[node.nodeLen()+int(node.keyLen):], v)
+	return node
+}
+
+func (ls *LockStore) getArena() *arena {
+	return (*arena)(atomic.LoadPointer(&ls.arenaPtr))
+}
+
+func (ls *LockStore) setArena(al *arena) {
+	atomic.StorePointer(&ls.arenaPtr, unsafe.Pointer(al))
+}
+
+func (ls *LockStore) randomHeight() int {
+	h := 1
+	for h < maxHeight && ls.rand.Uint64() < uint64(math.MaxUint64)/4 {
+		h++
+	}
+	return h
+}
+
+func (ls *LockStore) Delete(key []byte) bool {
+	listHeight := ls.getHeight()
+	var prevs [maxHeight + 1]*node
+	prevs[listHeight] = ls.head
+	var keyNode *node
+	for i := int(listHeight) - 1; i >= 0; i-- {
+		// Use higher level to speed up for current level.
+		var match bool
+		prevs[i], keyNode, match = ls.findSpliceForLevel(ls.getArena(), key, prevs[i+1], i)
+		if !match {
+			keyNode = nil
+		}
+	}
+	if keyNode == nil {
+		return false
+	}
+	for i := int(keyNode.height) - 1; i >= 0; i-- {
+		// Change the nexts from higher to lower, so the data is consistent at any point.
+		prevs[i].setNextAddr(i, keyNode.getNextAddr(i))
+	}
+	ls.getArena().free(keyNode.addr)
+	return true
+}

--- a/lockstore/lockstore_test.go
+++ b/lockstore/lockstore_test.go
@@ -1,0 +1,203 @@
+package lockstore
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockStore(t *testing.T) {
+	prefix := "ls"
+	n := 30000
+	ls := NewLockStore(1 << 10)
+	val := ls.Get([]byte("a"), nil)
+	require.Len(t, val, 0)
+
+	insertLockStore(ls, prefix, n)
+	numBlocks := len(ls.getArena().blocks)
+	checkLockStore(t, ls, prefix, n)
+	deleteLockStore(t, ls, prefix, n)
+	require.Equal(t, len(ls.getArena().blocks), numBlocks)
+	time.Sleep(reuseSafeDuration)
+	insertLockStore(ls, prefix, n)
+	// Because the height is random, we insert again, the block number may be different.
+	diff := len(ls.getArena().blocks) - numBlocks
+	require.True(t, diff < numBlocks/100)
+	require.Len(t, ls.Get(numToKey(n), nil), 0)
+	require.Len(t, ls.Get([]byte("abc"), nil), 0)
+}
+
+const keyFormat = "%s%020d"
+
+func insertLockStore(ls *LockStore, prefix string, n int) *LockStore {
+	perms := rand.Perm(n)
+	for _, v := range perms {
+		key := []byte(fmt.Sprintf(keyFormat, prefix, v))
+		ls.Insert(key, key)
+	}
+	return ls
+}
+
+func checkLockStore(t *testing.T, ls *LockStore, prefix string, n int) {
+	perms := rand.Perm(n)
+	for _, v := range perms {
+		key := []byte(fmt.Sprintf(keyFormat, prefix, v))
+		val := ls.Get(key, nil)
+		require.True(t, bytes.Equal(key, val))
+	}
+}
+
+func deleteLockStore(t *testing.T, ls *LockStore, prefix string, n int) {
+	perms := rand.Perm(n)
+	for _, v := range perms {
+		key := []byte(fmt.Sprintf(keyFormat, prefix, v))
+		require.True(t, ls.Delete(key), string(key))
+	}
+}
+
+func TestIterator(t *testing.T) {
+	ls := NewLockStore(1 << 10)
+	for i := 10; i < 1000; i += 10 {
+		key := []byte(fmt.Sprintf(keyFormat, "ls", i))
+		ls.Insert(key, bytes.Repeat(key, 10))
+	}
+	require.Len(t, ls.getArena().blocks, 33)
+	it := ls.NewIterator()
+	it.SeekToFirst()
+	checkKey(t, it, 10)
+	it.Next()
+	checkKey(t, it, 20)
+	it.SeekToFirst()
+	checkKey(t, it, 10)
+	it.SeekToLast()
+	checkKey(t, it, 990)
+	it.Seek(numToKey(11))
+	checkKey(t, it, 20)
+	it.Seek(numToKey(989))
+	checkKey(t, it, 990)
+	it.Seek(numToKey(0))
+	checkKey(t, it, 10)
+
+	it.Seek(numToKey(2000))
+	require.False(t, it.Valid())
+
+	it.Seek(numToKey(500))
+	checkKey(t, it, 500)
+	it.Prev()
+	checkKey(t, it, 490)
+	it.SeekForPrev(numToKey(100))
+	checkKey(t, it, 100)
+	it.SeekForPrev(numToKey(99))
+	checkKey(t, it, 90)
+
+	it.SeekForPrev(numToKey(2000))
+	checkKey(t, it, 990)
+}
+
+func checkKey(t *testing.T, it *Iterator, n int) {
+	require.True(t, it.Valid())
+	require.True(t, bytes.Equal(it.Key(), []byte(fmt.Sprintf(keyFormat, "ls", n))))
+	require.True(t, bytes.Equal(it.Value(), bytes.Repeat(it.Key(), 10)))
+}
+
+func numToKey(n int) []byte {
+	return []byte(fmt.Sprintf(keyFormat, "ls", n))
+}
+
+func TestConcurrent(t *testing.T) {
+	keyRange := 10
+	concurrentKeys := make([][]byte, keyRange)
+	for i := 0; i < keyRange; i++ {
+		concurrentKeys[i] = numToKey(i)
+	}
+
+	ls := NewLockStore(1 << 20)
+	// Starts 10 readers and 1 writer.
+	closeCh := make(chan bool)
+	for i := 0; i < keyRange; i++ {
+		go runReader(ls, closeCh, i)
+	}
+	ran := rand.New(rand.NewSource(time.Now().Unix()))
+	start := time.Now()
+	var totalInsert, totalDelete int
+	for {
+		if totalInsert%128 == 0 && time.Since(start) > time.Second*10 {
+			break
+		}
+		n := ran.Intn(keyRange)
+		key := concurrentKeys[n]
+		if ls.Insert(key, key) {
+			totalInsert++
+		}
+		n = ran.Intn(keyRange)
+		key = concurrentKeys[n]
+		if ls.Delete(key) {
+			totalDelete++
+		}
+	}
+	close(closeCh)
+	time.Sleep(time.Millisecond * 100)
+	arena := ls.getArena()
+	fmt.Println("total insert", totalInsert, "total delete", totalDelete)
+	fmt.Println(len(arena.pendingBlocks), len(arena.writableQueue), len(arena.blocks))
+}
+
+func runReader(ls *LockStore, closeCh chan bool, i int) {
+	key := numToKey(i)
+	buf := make([]byte, 100)
+	var n int
+	for {
+		n++
+		if n%128 == 0 {
+			select {
+			case <-closeCh:
+				fmt.Println("read", n)
+				return
+			default:
+			}
+		}
+		result := ls.Get(key, buf)
+		if len(result) > 0 && !bytes.Equal(key, result) {
+			panic("data corruption")
+		}
+	}
+}
+
+func BenchmarkLockStoreDeleteInsertGet(b *testing.B) {
+	ls := NewLockStore(1 << 23)
+	keys := make([][]byte, 10000)
+	for i := 0; i < 10000; i++ {
+		keys[i] = numToKey(i)
+		ls.Insert(keys[i], keys[i])
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	buf := make([]byte, 100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n := r.Intn(10000)
+		ls.Delete(keys[n])
+		ls.Insert(keys[n], keys[n])
+		ls.Get(keys[n], buf)
+	}
+}
+
+func BenchmarkLockStoreIterate(b *testing.B) {
+	ls := NewLockStore(1 << 23)
+	keys := make([][]byte, 10000)
+	for i := 0; i < 10000; i++ {
+		keys[i] = numToKey(i)
+		ls.Insert(keys[i], keys[i])
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		it := ls.NewIterator()
+		it.SeekToFirst()
+		for it.Valid() {
+			it.Next()
+		}
+	}
+}


### PR DESCRIPTION
A in-memory lock-free data-structure to store lock.
- allows single writer and multiple readers without lock.
- memory can be reused after all the entries in a block are deleted.