### PR TITLE
fix bugs found in high conflicting concurrent transaction workload.

### DIFF
--- a/tikv/types.go
+++ b/tikv/types.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/coocood/badger"
 	"github.com/juju/errors"
-	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/util/codec"
 )
 
@@ -85,10 +84,7 @@ func (l *mvccLock) MarshalBinary() []byte {
 	return buf
 }
 
-func lockToValue(lock mvccLock, commitTS uint64) (mvVal mvccValue, userMeta byte) {
-	if lock.op == uint8(kvrpcpb.Op_Del) {
-		userMeta = userMetaDelete
-	}
+func lockToValue(lock mvccLock, commitTS uint64) (mvVal mvccValue) {
 	mvVal.startTS = lock.startTS
 	mvVal.commitTS = commitTS
 	mvVal.value = lock.value


### PR DESCRIPTION
1. Fix `Cleanup` mistakenly write the batch to DB instead of lock store and use separate write batch type for Lock and DB to prevent error like this.

2. `Rollback` function should read all keys in lock store before read DB.

3. Fix delete key do actual delete instead of write tombstone.