### PR TITLE
fix WaitGroup

### DIFF
--- a/tikv/region.go
+++ b/tikv/region.go
@@ -369,6 +369,9 @@ func (rm *RegionManager) getRegionFromCtx(ctx *kvrpcpb.Context) (*regionCtx, *er
 	}
 	rm.mu.RLock()
 	ri := rm.regions[ctx.RegionId]
+	if ri != nil {
+		ri.refCount.Add(1)
+	}
 	rm.mu.RUnlock()
 	if ri == nil {
 		return nil, &errorpb.Error{

--- a/tikv/region.go
+++ b/tikv/region.go
@@ -383,6 +383,7 @@ func (rm *RegionManager) getRegionFromCtx(ctx *kvrpcpb.Context) (*regionCtx, *er
 	}
 	// Region epoch does not match.
 	if *ri.meta.GetRegionEpoch() != *ctx.GetRegionEpoch() {
+		ri.refCount.Done()
 		return nil, &errorpb.Error{
 			Message: "stale epoch",
 			StaleEpoch: &errorpb.StaleEpoch{

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -103,7 +103,6 @@ func newRequestCtx(svr *Server, ctx *kvrpcpb.Context, method string) (*requestCt
 	if req.regErr != nil {
 		return req, nil
 	}
-	req.regCtx.refCount.Add(1)
 	return req, nil
 }
 


### PR DESCRIPTION
After `WaitGroup.Wait` is called, another call on `Add` will panic, so call `Add` in the Lock to prevent this.