### PR TITLE
split rollbackGC batch

### DIFF
--- a/tikv/write.go
+++ b/tikv/write.go
@@ -269,6 +269,10 @@ func (w *rollbackGCWorker) run() {
 			if tsSub(latestTS, ts) > time.Minute {
 				lockBatch.rollbackGC(safeCopy(it.Key()))
 			}
+			if len(lockBatch.entries) >= 1000 {
+				store.writeLocks(lockBatch)
+				lockBatch.entries = lockBatch.entries[:0]
+			}
 		}
 		if len(lockBatch.entries) == 0 {
 			continue


### PR DESCRIPTION
In TPCC benchmark, the number of rollback keys in one minute is very large, up to hundreds of thousands, It increases max latency a lot.

Split the rollbackGC batch into small batches to avoid high latency.
Although it doesn't improve the throughput.