### PR TITLE
optimize count(*) and DecodeHandle.

### DIFF
--- a/tikv/cop_handler.go
+++ b/tikv/cop_handler.go
@@ -216,6 +216,11 @@ func (svr *Server) buildTableScan(ctx *dagContext, executor *tipb.Executor) (*ta
 		buf:       make([][]byte, len(columns)),
 		loc:       ctx.evalCtx.sc.TimeZone,
 	}
+	if len(columns) == 1 {
+		if columns[0].PkHandle || columns[0].ColumnId == model.ExtraHandleID {
+			e.handleOnly = true
+		}
+	}
 	if ctx.dagReq.CollectRangeCounts != nil && *ctx.dagReq.CollectRangeCounts {
 		e.counts = make([]int64, len(ranges))
 	}

--- a/tikv/executor.go
+++ b/tikv/executor.go
@@ -61,9 +61,10 @@ type tableScanExec struct {
 	lockChecked bool
 
 	// for chunk
-	tps []*types.FieldType
-	buf [][]byte
-	loc *time.Location
+	tps        []*types.FieldType
+	buf        [][]byte
+	loc        *time.Location
+	handleOnly bool
 
 	src executor
 }
@@ -217,9 +218,9 @@ func (e *tableScanExec) fillChunkFromPoint(chk *chunk.Chunk, key kv.Key) error {
 	if len(val) == 0 {
 		return nil
 	}
-	handle, err := tablecodec.DecodeRowKey(key)
-	if err != nil {
-		return errors.Trace(err)
+	handle, ok := e.decodeRowKeyHandle(key)
+	if !ok {
+		return errors.Errorf("invalid record key %q", key)
 	}
 	err = e.decodeChunkRow(handle, val, chk)
 	return errors.Trace(err)
@@ -267,14 +268,18 @@ func (e *tableScanExec) fillChunkFromRange(chk *chunk.Chunk, ran kv.KeyRange) (e
 	var lastKey []byte
 	scanFunc := func(key, val []byte) error {
 		lastKey = key
-		handle, err1 := tablecodec.DecodeRowKey(key)
-		if err != nil {
-			return errors.Trace(err1)
+		handle, ok := e.decodeRowKeyHandle(key)
+		if !ok {
+			return errors.Errorf("invalid record key %q", key)
 		}
-		err1 = e.decodeChunkRow(handle, val, chk)
+		if e.handleOnly {
+			chk.AppendInt64(0, handle)
+			return nil
+		}
+		err := e.decodeChunkRow(handle, val, chk)
 		// errors.Trace can't be inlined by compiler, let's check error explicitly
-		if err1 != nil {
-			return errors.Trace(err1)
+		if err != nil {
+			return errors.Trace(err)
 		}
 		return nil
 	}
@@ -296,6 +301,40 @@ func (e *tableScanExec) fillChunkFromRange(chk *chunk.Chunk, ran kv.KeyRange) (e
 		e.seekKey = []byte(kv.Key(lastKey).PrefixNext())
 	}
 	return
+}
+
+const (
+	tablePrefixLength     = 1
+	idLen                 = 8
+	recordPrefixSepLength = 2
+
+	prefixLen          = 1 + idLen /*tableID*/ + 2
+	recordRowKeyLen    = prefixLen + idLen /*handle*/
+	tablePrefix        = 't'
+	recordPrefixFirst  = '_'
+	recordPrefixSecond = 'r'
+)
+
+func (e *tableScanExec) decodeRowKeyHandle(key []byte) (int64, bool) {
+	if len(key) != recordRowKeyLen {
+		return 0, false
+	}
+	if !hasTablePrefix(key) {
+		return 0, false
+	}
+	if !hasRecordPrefixSep(key[prefixLen-2], key[prefixLen-1]) {
+		return 0, false
+	}
+	u := binary.BigEndian.Uint64(key[prefixLen:])
+	return codec.DecodeCmpUintToInt(u), true
+}
+
+func hasTablePrefix(key kv.Key) bool {
+	return key[0] == tablePrefix
+}
+
+func hasRecordPrefixSep(first, second byte) bool {
+	return first == recordPrefixFirst && second == recordPrefixSecond
 }
 
 func (e *tableScanExec) fillRows() error {


### PR DESCRIPTION
1. Do not decode the row if only handle column is needed.

2, Implement a more efficient decodeRowKeyHandle.