### PR TITLE
support more executors in closure executor

### DIFF
--- a/tikv/closure_exec.go
+++ b/tikv/closure_exec.go
@@ -4,95 +4,200 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/types"
 	"github.com/juju/errors"
-	"github.com/pingcap/tipb/go-tipb"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
+	mockpkg "github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tipb/go-tipb"
 )
 
 // tryBuildClosureExecutor tries to build a closureExecutor for the DAGRequest.
 // currently, only 'count(*)' is supported, but we can support all kinds of requests in the future.
-func (svr *Server) tryBuildClosureExecutor(dagCtx *dagContext, dagReq *tipb.DAGRequest) *closureExecutor {
-	executors := dagReq.Executors
-	if len(executors) != 2 {
-		return nil
+func (svr *Server) tryBuildClosureExecutor(dagCtx *dagContext, dagReq *tipb.DAGRequest) (*closureExecutor, error) {
+	ce, err := svr.newClosureExecutor(dagCtx, dagReq)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	var cols []*tipb.ColumnInfo
-	var unique bool
-	switch executors[0].Tp {
+	executors := dagReq.Executors
+	scanExec := executors[0]
+	if scanExec.Tp == tipb.ExecType_TypeTableScan {
+		ce.processFunc = ce.tableScanProcess
+	} else {
+		ce.processFunc = ce.indexScanProcess
+	}
+	ce.finishFunc = ce.scanFinish
+	if len(executors) == 1 {
+		return ce, nil
+	}
+	secondExec := executors[1]
+	switch secondExec.Tp {
+	case tipb.ExecType_TypeStreamAgg:
+		return svr.tryBuildAggClosureExecutor(ce, executors)
+	case tipb.ExecType_TypeLimit:
+		ce.limit = int(secondExec.Limit.Limit)
+		return ce, nil
+	case tipb.ExecType_TypeSelection:
+		ce.selectionCtx.conditions, err = convertToExprs(ce.sc, ce.fieldTps, secondExec.Selection.Conditions)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(executors) > 2 {
+			if executors[2].Tp != tipb.ExecType_TypeLimit {
+				return nil, nil
+			}
+			ce.limit = int(executors[2].Limit.Limit)
+		}
+		ce.processFunc = ce.selectionProcess
+		return ce, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (svr *Server) newClosureExecutor(dagCtx *dagContext, dagReq *tipb.DAGRequest) (*closureExecutor, error) {
+	e := &closureExecutor{
+		evalContext: dagCtx.evalCtx,
+		reqCtx:      dagCtx.reqCtx,
+		outputOff:   dagReq.OutputOffsets,
+		mvccStore:   svr.mvccStore,
+		startTS:     dagReq.StartTs,
+		limit:       math.MaxInt64,
+	}
+	seCtx := mockpkg.NewContext()
+	seCtx.GetSessionVars().StmtCtx = e.sc
+	e.seCtx = seCtx
+	executors := dagReq.Executors
+	scanExec := executors[0]
+	switch scanExec.Tp {
 	case tipb.ExecType_TypeTableScan:
 		tblScan := executors[0].TblScan
-		cols = tblScan.Columns
-		unique = true
+		e.unique = true
+		e.scanCtx.desc = tblScan.Desc
 	case tipb.ExecType_TypeIndexScan:
 		idxScan := executors[0].IdxScan
-		cols = idxScan.Columns
-		unique = idxScan.GetUnique()
+		e.unique = idxScan.GetUnique()
+		e.scanCtx.desc = idxScan.Desc
+		e.initIdxScanCtx()
 	default:
 		panic(fmt.Sprintf("unknown first executor type %s", executors[0].Tp))
 	}
-	if len(cols) != 1 {
-		return nil
+	ranges, err := svr.extractKVRanges(dagCtx.reqCtx.regCtx, dagCtx.keyRanges, e.scanCtx.desc)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	col := cols[0]
-	if !col.PkHandle {
-		return nil
+	e.kvRanges = ranges
+	e.scanCtx.chk = chunk.NewChunkWithCapacity(e.fieldTps, 32)
+	e.scanCtx.cols = make([][]byte, len(e.fieldTps))
+	return e, nil
+}
+
+func (e *closureExecutor) initIdxScanCtx() {
+	e.idxScanCtx = new(idxScanCtx)
+	e.idxScanCtx.columnLen = len(e.columnInfos)
+	e.idxScanCtx.pkStatus = pkColNotExists
+	lastColumn := e.columnInfos[len(e.columnInfos)-1]
+	// The PKHandle column info has been collected in ctx.
+	if lastColumn.GetPkHandle() {
+		if mysql.HasUnsignedFlag(uint(lastColumn.GetFlag())) {
+			e.idxScanCtx.pkStatus = pkColIsUnsigned
+		} else {
+			e.idxScanCtx.pkStatus = pkColIsSigned
+		}
+		e.idxScanCtx.columnLen--
+	} else if lastColumn.ColumnId == model.ExtraHandleID {
+		e.idxScanCtx.pkStatus = pkColIsSigned
+		e.idxScanCtx.columnLen--
+	}
+}
+
+func (svr *Server) isCountAgg(pbAgg *tipb.Aggregation) bool {
+	if len(pbAgg.AggFunc) == 1 && len(pbAgg.GroupBy) == 0 {
+		aggFunc := pbAgg.AggFunc[0]
+		if aggFunc.Tp == tipb.ExprType_Count && len(aggFunc.Children) == 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func (svr *Server) tryBuildAggClosureExecutor(e *closureExecutor, executors []*tipb.Executor) (*closureExecutor, error) {
+	if len(executors) > 2 {
+		return nil, nil
 	}
 	agg := executors[1].Aggregation
-	if agg == nil {
-		return nil
+	if !svr.isCountAgg(agg) {
+		return nil, nil
 	}
-	if len(agg.AggFunc) != 1 {
-		return nil
+	child := agg.AggFunc[0].Children[0]
+	switch child.Tp {
+	case tipb.ExprType_ColumnRef:
+		_, idx, err := codec.DecodeInt(child.Val)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		e.aggCtx.colIdx = int(idx)
+		e.processFunc = e.countColumnProcess
+	default:
+		e.processFunc = e.countStarProcess
 	}
-	if len(agg.GroupBy) != 0 {
-		return nil
-	}
-	aggFunc := agg.AggFunc[0]
-	if aggFunc.Tp != tipb.ExprType_Count {
-		return nil
-	}
-	if len(aggFunc.Children) != 1 {
-		return nil
-	}
-	if aggFunc.Children[0].Tp != tipb.ExprType_Int64 {
-		return nil
-	}
-	ranges, err := svr.extractKVRanges(dagCtx.reqCtx.regCtx, dagCtx.keyRanges, false)
-	if err != nil {
-		return nil
-	}
-	ce := &closureExecutor{
-		dagCtx: dagCtx,
-		mvccStore: svr.mvccStore,
-		kvRanges: ranges,
-		startTS: dagReq.StartTs,
-		unique:  unique,
-	}
-	ce.processFunc = ce.countStarProcess
-	ce.finishFunc = ce.countStarFinish
-	return ce
+	e.finishFunc = e.countFinish
+	return e, nil
 }
 
 // closureExecutor is an execution engine that flatten the DAGRequest.Executors to a single closure `processFunc` that
 // process key/value pairs. We can define many closures for different kinds of requests, try to use the specially
 // optimized one for some frequently used query.
 type closureExecutor struct {
-	dagCtx      *dagContext
-	mvccStore   *MVCCStore
-	kvRanges    []kv.KeyRange
-	startTS     uint64
-	ignoreLock  bool
-	lockChecked bool
-	rangeBuf    []byte
+	*evalContext
+	reqCtx       *requestCtx
+	outputOff    []uint32
+	mvccStore    *MVCCStore
+	seCtx        sessionctx.Context
+	kvRanges     []kv.KeyRange
+	startTS      uint64
+	ignoreLock   bool
+	lockChecked  bool
+	scanCtx      scanCtx
+	idxScanCtx   *idxScanCtx
+	selectionCtx selectionCtx
+	aggCtx       aggCtx
 
-	count       int64
-	unique      bool
+	rowCount int
+	unique   bool
+	limit    int
 
 	oldChunks   []tipb.Chunk
-	processFunc func (key, val []byte) error
+	oldRowBuf   []byte
+	processFunc func(key, val []byte) error
 	finishFunc  func() error
+}
+
+type scanCtx struct {
+	count int
+	limit int
+	chk   *chunk.Chunk
+	cols  [][]byte
+	desc  bool
+}
+
+type idxScanCtx struct {
+	pkStatus  int
+	columnLen int
+}
+
+type aggCtx struct {
+	colIdx int
+}
+
+type selectionCtx struct {
+	conditions []expression.Expression
 }
 
 func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
@@ -100,22 +205,32 @@ func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	dbReader := e.dagCtx.reqCtx.getDBReader()
+	dbReader := e.reqCtx.getDBReader()
 	for _, ran := range e.kvRanges {
-		if ran.IsPoint() {
+		if e.unique && ran.IsPoint() {
 			val, err := dbReader.Get(ran.StartKey, e.startTS)
 			if err != nil {
 				return nil, errors.Trace(err)
+			}
+			if len(val) == 0 {
+				continue
 			}
 			err = e.processFunc(ran.StartKey, val)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
 		} else {
-			err = dbReader.Scan(ran.StartKey, ran.EndKey, math.MaxInt64, e.startTS, e.processFunc)
+			if e.scanCtx.desc {
+				err = dbReader.ReverseScan(ran.StartKey, ran.EndKey, math.MaxInt64, e.startTS, e.processFunc)
+			} else {
+				err = dbReader.Scan(ran.StartKey, ran.EndKey, math.MaxInt64, e.startTS, e.processFunc)
+			}
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
+		}
+		if e.rowCount == e.limit {
+			break
 		}
 	}
 	err = e.finishFunc()
@@ -136,18 +251,187 @@ func (e *closureExecutor) checkRangeLock() error {
 }
 
 // countStarProcess is used for `count(*)`.
-func (ce *closureExecutor) countStarProcess(key, value []byte) error {
-	ce.count++
+func (e *closureExecutor) countStarProcess(key, value []byte) error {
+	e.rowCount++
 	return nil
 }
 
-// countStarFinish is used for `count(*)`.
-func (ce *closureExecutor) countStarFinish() error {
-	d := types.NewIntDatum(ce.count)
-	rowData, err := codec.EncodeValue(ce.dagCtx.evalCtx.sc, nil, d)
+// countFinish is used for `count(*)`.
+func (e *closureExecutor) countFinish() error {
+	d := types.NewIntDatum(int64(e.rowCount))
+	rowData, err := codec.EncodeValue(e.sc, nil, d)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	ce.oldChunks = appendRow(ce.oldChunks, rowData, 0)
+	e.oldChunks = appendRow(e.oldChunks, rowData, 0)
 	return nil
+}
+
+func (e *closureExecutor) countColumnProcess(key, value []byte) error {
+	if e.idxScanCtx != nil {
+		values, _, err := tablecodec.CutIndexKeyNew(key, e.idxScanCtx.columnLen)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if values[0][0] != codec.NilFlag {
+			e.rowCount++
+		}
+	} else {
+		err := cutRowToBuf(value, e.colIDs, e.scanCtx.cols)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		val := e.scanCtx.cols[e.aggCtx.colIdx]
+		if len(val) > 0 && val[0] != codec.NilFlag {
+			e.rowCount++
+		}
+	}
+	return nil
+}
+
+func (e *closureExecutor) tableScanProcess(key, value []byte) error {
+	if e.rowCount == e.limit {
+		return ScanBreak
+	}
+	e.rowCount++
+	err := e.tableScanProcessCore(key, value)
+	if e.scanCtx.chk.NumRows() == chunkMaxRows {
+		err = e.chunkToOldChunk(e.scanCtx.chk)
+	}
+	return err
+}
+
+func (e *closureExecutor) tableScanProcessCore(key, value []byte) error {
+	handle, err := tablecodec.DecodeRowKey(key)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = cutRowToBuf(value, e.colIDs, e.scanCtx.cols)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	chk := e.scanCtx.chk
+	decoder := codec.NewDecoder(chk, e.sc.TimeZone)
+	for i, val := range e.scanCtx.cols {
+		col := e.columnInfos[i]
+		if val == nil {
+			if col.GetPkHandle() || col.ColumnId == model.ExtraHandleID {
+				e.scanCtx.chk.AppendInt64(i, handle)
+				continue
+			}
+			if len(col.DefaultVal) != 0 {
+				val = col.DefaultVal
+			} else {
+				val = []byte{codec.NilFlag}
+			}
+		}
+		_, err = decoder.DecodeOne(val, i, e.fieldTps[i])
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func (e *closureExecutor) scanFinish() error {
+	return e.chunkToOldChunk(e.scanCtx.chk)
+}
+
+func (e *closureExecutor) indexScanProcess(key, value []byte) error {
+	if e.rowCount == e.limit {
+		return ScanBreak
+	}
+	e.rowCount++
+	err := e.indexScanProcessCore(key, value)
+	if e.scanCtx.chk.NumRows() == chunkMaxRows {
+		err = e.chunkToOldChunk(e.scanCtx.chk)
+	}
+	return err
+}
+
+func (e *closureExecutor) indexScanProcessCore(key, value []byte) error {
+	colLen := e.idxScanCtx.columnLen
+	pkStatus := e.idxScanCtx.pkStatus
+	chk := e.scanCtx.chk
+	values, b, err := tablecodec.CutIndexKeyNew(key, colLen)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	decoder := codec.NewDecoder(chk, e.sc.TimeZone)
+	for i, colVal := range values {
+		_, err = decoder.DecodeOne(colVal, i, e.fieldTps[i])
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if len(b) > 0 {
+		if pkStatus != pkColNotExists {
+			_, err = decoder.DecodeOne(b, colLen, e.fieldTps[colLen])
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	} else if pkStatus != pkColNotExists {
+		handle, err := decodeHandle(value)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		chk.AppendInt64(colLen, handle)
+	}
+	return nil
+}
+
+func (e *closureExecutor) chunkToOldChunk(chk *chunk.Chunk) error {
+	var oldRow []types.Datum
+	for i := 0; i < chk.NumRows(); i++ {
+		oldRow = oldRow[:0]
+		for _, outputOff := range e.outputOff {
+			d := chk.GetRow(i).GetDatum(int(outputOff), e.fieldTps[outputOff])
+			oldRow = append(oldRow, d)
+		}
+		var err error
+		e.oldRowBuf, err = codec.EncodeValue(e.sc, e.oldRowBuf[:0], oldRow...)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		e.oldChunks = appendRow(e.oldChunks, e.oldRowBuf, i)
+	}
+	chk.Reset()
+	return nil
+}
+
+func (e *closureExecutor) selectionProcess(key, value []byte) error {
+	if e.rowCount == e.limit {
+		return ScanBreak
+	}
+	var err error
+	if e.idxScanCtx != nil {
+		err = e.indexScanProcessCore(key, value)
+	} else {
+		err = e.tableScanProcessCore(key, value)
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+	chk := e.scanCtx.chk
+	row := chk.GetRow(chk.NumRows() - 1)
+	ok := true
+	for _, expr := range e.selectionCtx.conditions {
+		i, _, err := expr.EvalInt(e.seCtx, row)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if i == 0 {
+			ok = false
+			chk.TruncateTo(chk.NumRows() - 1)
+			break
+		}
+	}
+	if ok {
+		e.rowCount++
+		if e.scanCtx.chk.NumRows() == chunkMaxRows {
+			err = e.chunkToOldChunk(e.scanCtx.chk)
+		}
+	}
+	return err
 }

--- a/tikv/cop_handler.go
+++ b/tikv/cop_handler.go
@@ -7,13 +7,10 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/juju/errors"
-	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/tikvpb"
-	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/executor/aggfuncs"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/kv"
@@ -23,7 +20,6 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	mockpkg "github.com/pingcap/tidb/util/mock"
 	tipb "github.com/pingcap/tipb/go-tipb"
@@ -62,15 +58,6 @@ func (svr *Server) handleCopDAGRequest(reqCtx *requestCtx, req *coprocessor.Requ
 		return buildResp(chunks, nil, err, dagCtx.evalCtx.sc.GetWarnings(), time.Since(startTime))
 	}
 	e, err := svr.buildDAGExecutor(dagCtx, dagReq.Executors)
-	switch x := e.(type) {
-	case *tableScanExec, *indexScanExec, *limitExec, *selectionExec:
-		return svr.handleCopDAGRequestInChunk(dagCtx, e, dagReq, startTime)
-	case *streamAggExec:
-		// TODO: remove the check when SUM is supported.
-		if x.newAggFuncs != nil {
-			return svr.handleCopDAGRequestInChunk(dagCtx, e, dagReq, startTime)
-		}
-	}
 	ctx := context.TODO()
 	for {
 		var row [][]byte
@@ -90,43 +77,6 @@ func (svr *Server) handleCopDAGRequest(reqCtx *requestCtx, req *coprocessor.Requ
 	}
 	warnings := dagCtx.evalCtx.sc.GetWarnings()
 	return buildResp(chunks, e.Counts(), err, warnings, time.Since(startTime))
-}
-
-func (svr *Server) handleCopDAGRequestInChunk(dagCtx *dagContext, e executor, dagReq *tipb.DAGRequest, startTime time.Time) *coprocessor.Response {
-	ctx := context.TODO()
-	var oldChunks []tipb.Chunk
-	var rowCnt int
-	var err error
-	tps := e.fieldTypes()
-	chk := chunk.NewChunkWithCapacity(tps, 8)
-	for {
-		err = e.nextChunk(ctx, chk)
-		if err != nil {
-			break
-		}
-		if chk.NumRows() == 0 {
-			break
-		}
-		var oldRow []types.Datum
-		for i := 0; i < chk.NumRows(); i++ {
-			oldRow = oldRow[:0]
-			for _, outputOff := range dagReq.OutputOffsets {
-				d := chk.GetRow(i).GetDatum(int(outputOff), tps[outputOff])
-				oldRow = append(oldRow, d)
-			}
-			rowStr, err := types.DatumsToString(oldRow, true)
-			log.Info(rowStr, err)
-			var rowData []byte
-			rowData, err = codec.EncodeValue(dagCtx.evalCtx.sc, nil, oldRow...)
-			if err != nil {
-				break
-			}
-			oldChunks = appendRow(oldChunks, rowData, rowCnt)
-			rowCnt++
-		}
-	}
-	warnings := dagCtx.evalCtx.sc.GetWarnings()
-	return buildResp(oldChunks, e.Counts(), err, warnings, time.Since(startTime))
 }
 
 func (svr *Server) buildDAG(reqCtx *requestCtx, req *coprocessor.Request) (*dagContext, *tipb.DAGRequest, error) {
@@ -215,7 +165,6 @@ func (svr *Server) buildDAGExecutor(ctx *dagContext, executors []*tipb.Executor)
 }
 
 func (svr *Server) buildTableScan(ctx *dagContext, executor *tipb.Executor) (*tableScanExec, error) {
-	columns := ctx.evalCtx.columnInfos
 	ranges, err := svr.extractKVRanges(ctx.reqCtx.regCtx, ctx.keyRanges, executor.TblScan.Desc)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -228,12 +177,6 @@ func (svr *Server) buildTableScan(ctx *dagContext, executor *tipb.Executor) (*ta
 		startTS:   ctx.dagReq.GetStartTs(),
 		mvccStore: svr.mvccStore,
 		reqCtx:    ctx.reqCtx,
-		tps:       ctx.evalCtx.fieldTps,
-		cols:      make([][]byte, len(columns)),
-		loc:       ctx.evalCtx.sc.TimeZone,
-	}
-	if len(columns) == 1 && columns[0].PkHandle {
-		e.handleOnly = true
 	}
 	if ctx.dagReq.CollectRangeCounts != nil && *ctx.dagReq.CollectRangeCounts {
 		e.counts = make([]int64, len(ranges))
@@ -342,10 +285,6 @@ func (svr *Server) buildHashAgg(ctx *dagContext, executor *tipb.Executor) (*hash
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	tps := make([]*types.FieldType, len(aggs))
-	for i := 0; i < len(aggs); i++ {
-		tps[i] = fieldTypeFromPBFieldType(pbAgg.AggFunc[i].FieldType)
-	}
 
 	return &hashAggExec{
 		evalCtx:           ctx.evalCtx,
@@ -355,7 +294,6 @@ func (svr *Server) buildHashAgg(ctx *dagContext, executor *tipb.Executor) (*hash
 		groupKeys:         make([][]byte, 0),
 		relatedColOffsets: relatedColOffsets,
 		row:               make([]types.Datum, len(ctx.evalCtx.columnInfos)),
-		tps:               tps,
 	}, nil
 }
 
@@ -369,13 +307,6 @@ func (svr *Server) buildStreamAgg(ctx *dagContext, executor *tipb.Executor) (*st
 	for i, agg := range aggs {
 		aggCtxs[i] = agg.CreateContext(ctx.evalCtx.sc)
 	}
-	tps := make([]*types.FieldType, 0, len(groupBys)+len(aggs))
-	for i := 0; i < len(groupBys); i++ {
-		tps = append(tps, groupBys[i].GetType())
-	}
-	for i := 0; i < len(aggs); i++ {
-		tps = append(tps, fieldTypeFromPBFieldType(pbAgg.AggFunc[i].FieldType))
-	}
 	seCtx := mockpkg.NewContext()
 	seCtx.GetSessionVars().StmtCtx = ctx.evalCtx.sc
 	e := &streamAggExec{
@@ -386,43 +317,8 @@ func (svr *Server) buildStreamAgg(ctx *dagContext, executor *tipb.Executor) (*st
 		currGroupByValues: make([][]byte, 0),
 		relatedColOffsets: relatedColOffsets,
 		row:               make([]types.Datum, len(ctx.evalCtx.columnInfos)),
-		seCtx:             seCtx,
-		tps:               tps,
-	}
-	groupKeyLen := len(e.groupByExprs)
-	// Try to use the new agg frame work.
-	aggFuncs := make([]aggfuncs.AggFunc, len(pbAgg.AggFunc))
-	for i, expr := range pbAgg.AggFunc {
-		args := make([]expression.Expression, 0, len(expr.Children))
-		for _, child := range expr.Children {
-			arg, err := expression.PBToExpr(child, ctx.evalCtx.fieldTps, ctx.evalCtx.sc)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			args = append(args, arg)
-		}
-		name, err := aggTypeToName(expr.Tp)
-		if err != nil {
-			// If not supported, execute in the old way.
-			return e, nil
-		}
-		desc := aggregation.NewAggFuncDesc(seCtx, name, args, false)
-		aggFuncs[i] = aggfuncs.Build(seCtx, desc, groupKeyLen+i)
-	}
-	e.newAggFuncs = aggFuncs
-	e.partialResults = make([]aggfuncs.PartialResult, 0, len(e.newAggFuncs))
-	for _, newAggFunc := range e.newAggFuncs {
-		e.partialResults = append(e.partialResults, newAggFunc.AllocPartialResult())
 	}
 	return e, nil
-}
-
-func aggTypeToName(tp tipb.ExprType) (string, error) {
-	switch tp {
-	case tipb.ExprType_Count:
-		return ast.AggFuncCount, nil
-	}
-	return "", errors.New("unknown aggregation type")
 }
 
 func (svr *Server) buildTopN(ctx *dagContext, executor *tipb.Executor) (*topNExec, error) {

--- a/tikv/executor.go
+++ b/tikv/executor.go
@@ -36,8 +36,6 @@ type executor interface {
 	ResetCounts()
 	Counts() []int64
 	Next(ctx context.Context) ([][]byte, error)
-	nextChunk(ctx context.Context, chk *chunk.Chunk) error
-	fieldTypes() []*types.FieldType
 	// Cursor returns the key gonna to be scanned by the Next() function.
 	Cursor() (key []byte, desc bool)
 }
@@ -59,12 +57,6 @@ type tableScanExec struct {
 	counts      []int64
 	ignoreLock  bool
 	lockChecked bool
-
-	// for chunk
-	tps        []*types.FieldType
-	cols       [][]byte
-	loc        *time.Location
-	handleOnly bool
 
 	src executor
 }
@@ -166,138 +158,9 @@ func (e *tableScanExec) checkRangeLock() error {
 
 const chunkMaxRows = 1024
 
-func (e *tableScanExec) nextChunk(ctx context.Context, chk *chunk.Chunk) error {
-	chk.Reset()
-	err := e.checkRangeLock()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	for e.rangeCursor < len(e.kvRanges) {
-		ran := e.kvRanges[e.rangeCursor]
-		if ran.IsPoint() {
-			err = e.fillChunkFromPoint(chk, ran.StartKey)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			e.nextRange()
-			if chk.NumRows() == chunkMaxRows {
-				return nil
-			}
-		} else {
-			err = e.fillChunkFromRange(chk, ran)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			if chk.NumRows() == chunkMaxRows {
-				// When chunk is full after fill from range, the range may not finished.
-				// So we do not increase range cursor here.
-				return nil
-			}
-			// If chunk is not full, the range is finished.
-			e.nextRange()
-		}
-	}
-	return nil
-}
-
 func (e *tableScanExec) nextRange() {
 	e.rangeCursor++
 	e.seekKey = nil
-}
-
-func (e *tableScanExec) fieldTypes() []*types.FieldType {
-	return e.tps
-}
-
-func (e *tableScanExec) fillChunkFromPoint(chk *chunk.Chunk, key kv.Key) error {
-	reader := e.reqCtx.getDBReader()
-	val, err := reader.Get(key, e.startTS)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(val) == 0 {
-		return nil
-	}
-	handle, err := tablecodec.DecodeRowKey(key)
-	if err != nil {
-		return errors.Errorf("invalid record key %q", key)
-	}
-	err = e.decodeChunkRow(handle, val, chk)
-	return errors.Trace(err)
-}
-
-func (e *tableScanExec) decodeChunkRow(handle int64, rowData []byte, chk *chunk.Chunk) error {
-	err := cutRowToBuf(rowData, e.colIDs, e.cols)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	decoder := codec.NewDecoder(chk, e.loc)
-	for i, val := range e.cols {
-		col := e.Columns[i]
-		if val == nil {
-			if col.GetPkHandle() || col.ColumnId == model.ExtraHandleID {
-				chk.AppendInt64(i, handle)
-				continue
-			}
-			if col.DefaultVal != nil {
-				val = col.DefaultVal
-			} else {
-				val = []byte{codec.NilFlag}
-			}
-		}
-		_, err = decoder.DecodeOne(val, i, e.tps[i])
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
-func (e *tableScanExec) fillChunkFromRange(chk *chunk.Chunk, ran kv.KeyRange) (err error) {
-	if e.seekKey == nil {
-		if e.Desc {
-			e.seekKey = ran.EndKey
-		} else {
-			e.seekKey = ran.StartKey
-		}
-	}
-	limit := chunkMaxRows - chk.NumRows()
-	var lastKey []byte
-	scanFunc := func(key, val []byte) error {
-		lastKey = key
-		handle, err := tablecodec.DecodeRowKey(key)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if e.handleOnly {
-			chk.AppendInt64(0, handle)
-			return nil
-		}
-		err = e.decodeChunkRow(handle, val, chk)
-		// errors.Trace can't be inlined by compiler, let's check error explicitly
-		if err != nil {
-			return errors.Trace(err)
-		}
-		return nil
-	}
-	reader := e.reqCtx.getDBReader()
-	if e.Desc {
-		err = reader.ReverseScan(ran.StartKey, e.seekKey, limit, e.startTS, scanFunc)
-	} else {
-		err = reader.Scan(e.seekKey, ran.EndKey, limit, e.startTS, scanFunc)
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if lastKey == nil {
-		return
-	}
-	if e.Desc {
-		e.seekKey = prefixPrev(lastKey)
-	} else {
-		e.seekKey = []byte(kv.Key(lastKey).PrefixNext())
-	}
-	return
 }
 
 func (e *tableScanExec) fillRows() error {
@@ -465,124 +328,6 @@ func (e *indexScanExec) Cursor() ([]byte, bool) {
 		return e.kvRanges[len(e.kvRanges)-1].StartKey, e.Desc
 	}
 	return e.kvRanges[len(e.kvRanges)-1].EndKey, e.Desc
-}
-
-func (e *indexScanExec) nextChunk(ctx context.Context, chk *chunk.Chunk) error {
-	chk.Reset()
-	err := e.checkRangeLock()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	for e.ranCursor < len(e.kvRanges) {
-		ran := e.kvRanges[e.ranCursor]
-		if e.isUnique() && ran.IsPoint() {
-			err = e.fillChunkFromPoint(chk, ran.StartKey)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			e.nextRange()
-			if chk.NumRows() == chunkMaxRows {
-				return nil
-			}
-		} else {
-			err = e.fillChunkFromRange(chk, ran)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			if chk.NumRows() == chunkMaxRows {
-				// When chunk is full after fill from range, the range may not finished.
-				// So we do not increase range cursor here.
-				return nil
-			}
-			// If chunk is not full, the range is finished.
-			e.nextRange()
-		}
-	}
-	return nil
-}
-
-func (e *indexScanExec) fillChunkFromPoint(chk *chunk.Chunk, key kv.Key) error {
-	reader := e.reqCtx.getDBReader()
-	val, err := reader.Get(key, e.startTS)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if len(val) == 0 {
-		return nil
-	}
-	err = e.decodeToChunk(chk, key, val)
-	return errors.Trace(err)
-}
-
-func (e *indexScanExec) decodeToChunk(chk *chunk.Chunk, key kv.Key, val []byte) error {
-	values, b, err := tablecodec.CutIndexKeyNew(key, e.colsLen)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	decoder := codec.NewDecoder(chk, e.loc)
-	for i, colVal := range values {
-		_, err = decoder.DecodeOne(colVal, i, e.tps[i])
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	if len(b) > 0 {
-		if e.pkStatus != pkColNotExists {
-			_, err = decoder.DecodeOne(b, e.colsLen, e.tps[e.colsLen])
-			if err != nil {
-				return errors.Trace(err)
-			}
-		}
-	} else if e.pkStatus != pkColNotExists {
-		handle, err := decodeHandle(val)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		chk.AppendInt64(e.colsLen, handle)
-	}
-	return nil
-}
-
-func (e *indexScanExec) fillChunkFromRange(chk *chunk.Chunk, ran kv.KeyRange) (err error) {
-	if e.seekKey == nil {
-		if e.Desc {
-			e.seekKey = ran.EndKey
-		} else {
-			e.seekKey = ran.StartKey
-		}
-	}
-	limit := chunkMaxRows - chk.NumRows()
-	var lastKey []byte
-	scanFunc := func(key, value []byte) error {
-		lastKey = key
-		err = e.decodeToChunk(chk, key, value)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		return nil
-	}
-	reader := e.reqCtx.getDBReader()
-	if e.Desc {
-		err = reader.ReverseScan(ran.StartKey, e.seekKey, limit, e.startTS, scanFunc)
-	} else {
-		err = reader.Scan(e.seekKey, ran.EndKey, limit, e.startTS, scanFunc)
-	}
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if lastKey == nil {
-		return
-	}
-	if e.Desc {
-		e.seekKey = prefixPrev(lastKey)
-	} else {
-		e.seekKey = []byte(kv.Key(lastKey).PrefixNext())
-	}
-	return nil
-}
-
-func (e *indexScanExec) fieldTypes() []*types.FieldType {
-	return e.tps
 }
 
 func (e *indexScanExec) checkRangeLock() error {
@@ -759,11 +504,7 @@ type selectionExec struct {
 	chkRow            chkMutRow
 	evalCtx           *evalContext
 	src               executor
-	srcChk            *chunk.Chunk
-	srcIter           *chunk.Iterator4Chunk
-	selected          []bool
 	seCtx             sessionctx.Context
-	inputRow          chunk.Row
 }
 
 func (e *selectionExec) SetSrcExec(exec executor) {
@@ -831,43 +572,6 @@ func (e *selectionExec) Next(ctx context.Context) (value [][]byte, err error) {
 			return value, nil
 		}
 	}
-}
-
-func (e *selectionExec) nextChunk(ctx context.Context, chk *chunk.Chunk) error {
-	chk.Reset()
-	if e.srcChk == nil {
-		e.srcChk = chunk.NewChunkWithCapacity(e.src.fieldTypes(), 16)
-		e.srcIter = chunk.NewIterator4Chunk(e.srcChk)
-	}
-	for {
-		for ; e.inputRow != e.srcIter.End(); e.inputRow = e.srcIter.Next() {
-			if !e.selected[e.inputRow.Idx()] {
-				continue
-			}
-			if chk.NumRows() == chunkMaxRows {
-				return nil
-			}
-			chk.AppendRow(e.inputRow)
-		}
-		err := e.src.nextChunk(ctx, e.srcChk)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		// no more data.
-		if e.srcChk.NumRows() == 0 {
-			return nil
-		}
-		e.selected, err = expression.VectorizedFilter(e.seCtx, e.conditions, e.srcIter, e.selected)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		e.inputRow = e.srcIter.Begin()
-	}
-	return nil
-}
-
-func (e *selectionExec) fieldTypes() []*types.FieldType {
-	return e.src.fieldTypes()
 }
 
 type topNExec struct {
@@ -969,44 +673,6 @@ func (e *topNExec) evalTopN(value [][]byte) error {
 	return errors.Trace(e.heap.err)
 }
 
-func (e *topNExec) nextChunk(ctx context.Context, chk *chunk.Chunk) error {
-	chk.Reset()
-	return nil
-}
-
-func (e *topNExec) loadToLimit(ctx context.Context) error {
-	for e.srcChks.Len() < e.heap.totalCount {
-		srcChk := chunk.NewChunkWithCapacity(e.src.fieldTypes(), chunkMaxRows)
-		err := e.src.nextChunk(ctx, srcChk)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if srcChk.NumRows() == 0 {
-			break
-		}
-		e.srcChks.Add(srcChk)
-	}
-	e.initPointers()
-	return nil
-}
-
-func (e *topNExec) initPointers() {
-	e.rowPtrs = make([]chunk.RowPtr, 0, e.srcChks.Len())
-	for chkIdx := 0; chkIdx < e.srcChks.NumChunks(); chkIdx++ {
-		rowChk := e.srcChks.GetChunk(chkIdx)
-		for rowIdx := 0; rowIdx < rowChk.NumRows(); rowIdx++ {
-			e.rowPtrs = append(e.rowPtrs, chunk.RowPtr{ChkIdx: uint32(chkIdx), RowIdx: uint32(rowIdx)})
-		}
-	}
-}
-
-func (e *topNExec) initCompareFuncs() {
-}
-
-func (e *topNExec) fieldTypes() []*types.FieldType {
-	return e.src.fieldTypes()
-}
-
 type limitExec struct {
 	limit  uint64
 	cursor uint64
@@ -1048,32 +714,6 @@ func (e *limitExec) Next(ctx context.Context) (value [][]byte, err error) {
 	}
 	e.cursor++
 	return value, nil
-}
-
-func (e *limitExec) nextChunk(ctx context.Context, chk *chunk.Chunk) error {
-	chk.Reset()
-	if e.cursor == e.limit {
-		return nil
-	}
-	err := e.src.nextChunk(ctx, chk)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if chk.NumRows() == 0 {
-		return nil
-	}
-	limitRemain := int(e.limit - e.cursor)
-	if chk.NumRows() > limitRemain {
-		chk.TruncateTo(limitRemain)
-		e.cursor = e.limit
-	} else {
-		e.cursor += uint64(chk.NumRows())
-	}
-	return nil
-}
-
-func (e *limitExec) fieldTypes() []*types.FieldType {
-	return e.src.fieldTypes()
 }
 
 func hasColVal(data [][]byte, colIDs map[int64]int, id int64) bool {

--- a/tikv/executor.go
+++ b/tikv/executor.go
@@ -227,9 +227,6 @@ func (e *tableScanExec) fillChunkFromPoint(chk *chunk.Chunk, key kv.Key) error {
 }
 
 func (e *tableScanExec) decodeChunkRow(handle int64, rowData []byte, chk *chunk.Chunk) error {
-	for i := range e.cols {
-		e.cols[i] = nil
-	}
 	err := cutRowToBuf(rowData, e.colIDs, e.cols)
 	if err != nil {
 		return errors.Trace(err)
@@ -1153,7 +1150,10 @@ func decodeHandle(data []byte) (int64, error) {
 
 // cutRowToBuf cuts encoded row into byte slices.
 // Row layout: colID1, value1, colID2, value2, .....
-func cutRowToBuf(data []byte, colIDs map[int64]int, buf [][]byte) error {
+func cutRowToBuf(data []byte, colIDs map[int64]int, colsBuf [][]byte) error {
+	for i := range colsBuf {
+		colsBuf[i] = nil
+	}
 	if data == nil {
 		return nil
 	}
@@ -1174,7 +1174,7 @@ func cutRowToBuf(data []byte, colIDs map[int64]int, buf [][]byte) error {
 		}
 		offset, ok := colIDs[int64(cid)]
 		if ok {
-			buf[offset] = b
+			colsBuf[offset] = b
 			cnt++
 		}
 	}


### PR DESCRIPTION
And remove partially implemented chunk execution framework code.

Now `tableScan` `indexScan` `limit` `selection` is supported along with `count` aggregation.

mysql_test is passed.