### PR TITLE
support the new row format

### DIFF
--- a/rowcodec/common.go
+++ b/rowcodec/common.go
@@ -1,0 +1,230 @@
+package rowcodec
+
+import (
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"strings"
+	"unsafe"
+
+	"github.com/juju/errors"
+)
+
+// CodecVer is the constant number that represent the new row format.
+const CodecVer = 128
+
+var invalidCodecVer = errors.New("invalid codec version")
+
+// First byte in the encoded value which specifies the encoding type.
+const (
+	NilFlag          byte = 0
+	BytesFlag        byte = 1
+	CompactBytesFlag byte = 2
+	IntFlag          byte = 3
+	UintFlag         byte = 4
+	VarintFlag       byte = 8
+)
+
+// XRow is the struct type used to access the new row format.
+type XRow struct {
+	// small:  colID []byte, offsets []uint16, optimized for most cases.
+	// large:  colID []uint32, offsets []uint32.
+	large          bool
+	numNotNullCols uint16
+	numNullCols    uint16
+	colIDs         []byte
+
+	// valFlags is used for converting new row format to old row format.
+	// It can be removed once TiDB implemented the new row format.
+	valFlags []byte
+	offsets  []uint16
+	data     []byte
+
+	// for large row
+	colIDs32  []uint32
+	offsets32 []uint32
+}
+
+// String implements the strings.Stringer interface.
+func (r XRow) String() string {
+	var colValStrs []string
+	for i := 0; i < int(r.numNotNullCols); i++ {
+		var colID, offStart, offEnd int64
+		if r.large {
+			colID = int64(r.colIDs32[i])
+			if i != 0 {
+				offStart = int64(r.offsets32[i-1])
+			}
+			offEnd = int64(r.offsets32[i])
+		} else {
+			colID = int64(r.colIDs[i])
+			if i != 0 {
+				offStart = int64(r.offsets[i-1])
+			}
+			offEnd = int64(r.offsets[i])
+		}
+		colValData := r.data[offStart:offEnd]
+		valFlag := r.valFlags[i]
+		var colValStr string
+		if valFlag == BytesFlag {
+			colValStr = fmt.Sprintf("(%d:'%s')", colID, colValData)
+		} else {
+			colValStr = fmt.Sprintf("(%d:%d)", colID, colValData)
+		}
+		colValStrs = append(colValStrs, colValStr)
+	}
+	return strings.Join(colValStrs, ",")
+}
+
+func (r *XRow) getData(i int) []byte {
+	var start, end uint32
+	if r.large {
+		if i > 0 {
+			start = r.offsets32[i-1]
+		}
+		end = r.offsets32[i]
+	} else {
+		if i > 0 {
+			start = uint32(r.offsets[i-1])
+		}
+		end = uint32(r.offsets[i])
+	}
+	return r.data[start:end]
+}
+
+func (r *XRow) setRowData(rowData []byte) error {
+	if rowData[0] != CodecVer {
+		return invalidCodecVer
+	}
+	r.large = rowData[1]&1 > 0
+	r.numNotNullCols = binary.LittleEndian.Uint16(rowData[2:])
+	r.numNullCols = binary.LittleEndian.Uint16(rowData[4:])
+	cursor := 6
+	r.valFlags = rowData[cursor : cursor+int(r.numNotNullCols)]
+	cursor += int(r.numNotNullCols)
+	if r.large {
+		colIDsLen := int(r.numNotNullCols+r.numNullCols) * 4
+		r.colIDs32 = bytesToU32Slice(rowData[cursor : cursor+colIDsLen])
+		cursor += colIDsLen
+		offsetsLen := int(r.numNotNullCols) * 4
+		r.offsets32 = bytesToU32Slice(rowData[cursor : cursor+offsetsLen])
+		cursor += offsetsLen
+	} else {
+		colIDsLen := int(r.numNotNullCols + r.numNullCols)
+		r.colIDs = rowData[cursor : cursor+colIDsLen]
+		cursor += colIDsLen
+		offsetsLen := int(r.numNotNullCols) * 2
+		r.offsets = bytes2U16Slice(rowData[cursor : cursor+offsetsLen])
+		cursor += offsetsLen
+	}
+	r.data = rowData[cursor:]
+	return nil
+}
+
+func bytesToU32Slice(b []byte) []uint32 {
+	if len(b) == 0 {
+		return nil
+	}
+	var u32s []uint32
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u32s))
+	hdr.Len = len(b) / 4
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
+	return u32s
+}
+
+func bytes2U16Slice(b []byte) []uint16 {
+	if len(b) == 0 {
+		return nil
+	}
+	var u16s []uint16
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u16s))
+	hdr.Len = len(b) / 2
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
+	return u16s
+}
+
+func u16SliceToBytes(u16s []uint16) []byte {
+	if len(u16s) == 0 {
+		return nil
+	}
+	var b []byte
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	hdr.Len = len(u16s) * 2
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&u16s[0]))
+	return b
+}
+
+func u32SliceToBytes(u32s []uint32) []byte {
+	if len(u32s) == 0 {
+		return nil
+	}
+	var b []byte
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	hdr.Len = len(u32s) * 4
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&u32s[0]))
+	return b
+}
+
+func encodeInt(iVal int64) []byte {
+	buf := make([]byte, 8)
+	if int64(int8(iVal)) == iVal {
+		buf[0] = byte(iVal)
+		buf = buf[:1]
+	} else if int64(int16(iVal)) == iVal {
+		binary.LittleEndian.PutUint16(buf, uint16(iVal))
+		buf = buf[:2]
+	} else if int64(int32(iVal)) == iVal {
+		binary.LittleEndian.PutUint32(buf, uint32(iVal))
+		buf = buf[:4]
+	} else {
+		binary.LittleEndian.PutUint64(buf, uint64(iVal))
+	}
+	return buf
+}
+
+func decodeInt(val []byte) int64 {
+	switch len(val) {
+	case 1:
+		return int64(int8(val[0]))
+	case 2:
+		return int64(int16(binary.LittleEndian.Uint16(val)))
+	case 4:
+		return int64(int32(binary.LittleEndian.Uint32(val)))
+	default:
+		return int64(binary.LittleEndian.Uint64(val))
+	}
+}
+
+func encodeUint(uVal uint64) []byte {
+	buf := make([]byte, 8)
+	if uint64(uint8(uVal)) == uVal {
+		buf[0] = byte(uVal)
+		buf = buf[:1]
+	} else if uint64(uint16(uVal)) == uVal {
+		binary.LittleEndian.PutUint16(buf, uint16(uVal))
+		buf = buf[:2]
+	} else if uint64(uint32(uVal)) == uVal {
+		binary.LittleEndian.PutUint32(buf, uint32(uVal))
+		buf = buf[:4]
+	} else {
+		binary.LittleEndian.PutUint64(buf, uint64(uVal))
+	}
+	return buf
+}
+
+func decodeUint(val []byte) uint64 {
+	switch len(val) {
+	case 1:
+		return uint64(val[0])
+	case 2:
+		return uint64(binary.LittleEndian.Uint16(val))
+	case 4:
+		return uint64(binary.LittleEndian.Uint32(val))
+	default:
+		return binary.LittleEndian.Uint64(val)
+	}
+}

--- a/rowcodec/decoder.go
+++ b/rowcodec/decoder.go
@@ -1,0 +1,218 @@
+package rowcodec
+
+import (
+	"math"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/codec"
+)
+
+// XRowDecoder decodes the row in new format to chunk.Chunk.
+type XRowDecoder struct {
+	XRow
+	schemaColIDs []int64
+	handleColID  int64
+	schemaTypes  []*types.FieldType
+	origDefaults [][]byte
+	loc          *time.Location
+}
+
+// NewXRowDecoder creates a NewXRowDecoder.
+func NewXRowDecoder(colIDs []int64, handleColID int64, tps []*types.FieldType, origDefaults [][]byte,
+	loc *time.Location) (*XRowDecoder, error) {
+	xOrigDefaultVals := make([][]byte, len(origDefaults))
+	for i := 0; i < len(origDefaults); i++ {
+		if len(origDefaults[i]) == 0 {
+			continue
+		}
+		xDefaultVal, err := convertDefaultValue(origDefaults[i])
+		if err != nil {
+			return nil, err
+		}
+		xOrigDefaultVals[i] = xDefaultVal
+	}
+	return &XRowDecoder{
+		schemaColIDs: colIDs,
+		handleColID:  handleColID,
+		schemaTypes:  tps,
+		origDefaults: xOrigDefaultVals,
+		loc:          loc,
+	}, nil
+}
+
+func convertDefaultValue(defaultVal []byte) (colVal []byte, err error) {
+	var d types.Datum
+	_, d, err = codec.DecodeOne(defaultVal)
+	if err != nil {
+		return
+	}
+	switch d.Kind() {
+	case types.KindNull:
+		return nil, nil
+	case types.KindInt64:
+		return encodeInt(d.GetInt64()), nil
+	case types.KindUint64:
+		return encodeUint(d.GetUint64()), nil
+	case types.KindString, types.KindBytes:
+		return d.GetBytes(), nil
+	case types.KindFloat32:
+		return encodeUint(uint64(math.Float32bits(d.GetFloat32()))), nil
+	case types.KindFloat64:
+		return encodeUint(math.Float64bits(d.GetFloat64())), nil
+	default:
+		return defaultVal[1:], nil
+	}
+}
+
+func (decoder *XRowDecoder) Decode(xRowData []byte, handle int64, chk *chunk.Chunk) error {
+	err := decoder.setRowData(xRowData)
+	if err != nil {
+		return err
+	}
+	for colIdx, colID := range decoder.schemaColIDs {
+		if colID == decoder.handleColID {
+			chk.AppendInt64(colIdx, handle)
+			continue
+		}
+		// Search the column in not-null columns array.
+		i, j := 0, int(decoder.numNotNullCols)
+		var found bool
+		for i < j {
+			h := int(uint(i+j) >> 1) // avoid overflow when computing h
+			// i ≤ h < j
+			var v int64
+			if decoder.large {
+				v = int64(decoder.colIDs32[h])
+			} else {
+				v = int64(decoder.colIDs[h])
+			}
+			if v < colID {
+				i = h + 1
+			} else if v > colID {
+				j = h
+			} else {
+				found = true
+				colData := decoder.getData(h)
+				err := decoder.decodeColData(colIdx, colData, chk)
+				if err != nil {
+					return err
+				}
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		// Search the column in null columns array.
+		i, j = int(decoder.numNotNullCols), int(decoder.numNotNullCols+decoder.numNullCols)
+		for i < j {
+			h := int(uint(i+j) >> 1) // avoid overflow when computing h
+			// i ≤ h < j
+			var v int64
+			if decoder.large {
+				v = int64(decoder.colIDs32[h])
+			} else {
+				v = int64(decoder.colIDs[h])
+			}
+			if v < colID {
+				i = h + 1
+			} else if v > colID {
+				j = h
+			} else {
+				found = true
+				break
+			}
+		}
+		if found || decoder.origDefaults[colIdx] == nil {
+			chk.AppendNull(colIdx)
+		} else {
+			err := decoder.decodeColData(colIdx, decoder.origDefaults[colIdx], chk)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (decoder *XRowDecoder) decodeColData(colIdx int, colData []byte, chk *chunk.Chunk) error {
+	ft := decoder.schemaTypes[colIdx]
+	switch ft.Tp {
+	case mysql.TypeLonglong, mysql.TypeLong, mysql.TypeInt24, mysql.TypeShort, mysql.TypeTiny, mysql.TypeYear:
+		if mysql.HasUnsignedFlag(ft.Flag) {
+			chk.AppendUint64(colIdx, decodeUint(colData))
+		} else {
+			chk.AppendInt64(colIdx, decodeInt(colData))
+		}
+	case mysql.TypeFloat:
+		_, fVal, err := codec.DecodeFloat(colData)
+		if err != nil {
+			return err
+		}
+		chk.AppendFloat32(colIdx, float32(fVal))
+	case mysql.TypeDouble:
+		_, fVal, err := codec.DecodeFloat(colData)
+		if err != nil {
+			return err
+		}
+		chk.AppendFloat64(colIdx, fVal)
+	case mysql.TypeVarString, mysql.TypeVarchar, mysql.TypeString,
+		mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		chk.AppendBytes(colIdx, colData)
+	case mysql.TypeNewDecimal:
+		_, dec, _, _, err := codec.DecodeDecimal(colData)
+		if err != nil {
+			return err
+		}
+		chk.AppendMyDecimal(colIdx, dec)
+	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
+		var t types.Time
+		t.Type = ft.Tp
+		t.Fsp = ft.Decimal
+		err := t.FromPackedUint(decodeUint(colData))
+		if err != nil {
+			return err
+		}
+		if ft.Tp == mysql.TypeTimestamp && !t.IsZero() {
+			err = t.ConvertTimeZone(time.UTC, decoder.loc)
+			if err != nil {
+				return err
+			}
+		}
+		chk.AppendTime(colIdx, t)
+	case mysql.TypeDuration:
+		var dur types.Duration
+		dur.Duration = time.Duration(decodeInt(colData))
+		dur.Fsp = ft.Decimal
+		chk.AppendDuration(colIdx, dur)
+	case mysql.TypeEnum:
+		// ignore error deliberately, to read empty enum value.
+		enum, err := types.ParseEnumValue(ft.Elems, decodeUint(colData))
+		if err != nil {
+			enum = types.Enum{}
+		}
+		chk.AppendEnum(colIdx, enum)
+	case mysql.TypeSet:
+		set, err := types.ParseSetValue(ft.Elems, decodeUint(colData))
+		if err != nil {
+			return err
+		}
+		chk.AppendSet(colIdx, set)
+	case mysql.TypeBit:
+		byteSize := (ft.Flen + 7) >> 3
+		chk.AppendBytes(colIdx, types.NewBinaryLiteralFromUint(decodeUint(colData), byteSize))
+	case mysql.TypeJSON:
+		var j json.BinaryJSON
+		j.TypeCode = colData[0]
+		j.Value = colData[1:]
+		chk.AppendJSON(colIdx, j)
+	default:
+		return errors.Errorf("unknown type %d", ft.Tp)
+	}
+	return nil
+}

--- a/rowcodec/encoder.go
+++ b/rowcodec/encoder.go
@@ -1,0 +1,242 @@
+package rowcodec
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/codec"
+)
+
+// XRowBuilder is used to build new row from an old row.
+type XRowBuilder struct {
+	row        XRow
+	sc         *stmtctx.StatementContext
+	tempColIDs []int64
+	values     []types.Datum
+	tempData   []byte
+}
+
+func (rb *XRowBuilder) SetOldRow(oldRow []byte) error {
+	for len(oldRow) > 1 {
+		var d types.Datum
+		var err error
+		oldRow, d, err = codec.DecodeOne(oldRow)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		colID := d.GetInt64()
+		oldRow, d, err = codec.DecodeOne(oldRow)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if colID > 255 {
+			rb.row.large = true
+		}
+		if d.IsNull() {
+			rb.row.numNullCols++
+		} else {
+			rb.row.numNotNullCols++
+		}
+		rb.tempColIDs = append(rb.tempColIDs, colID)
+		rb.values = append(rb.values, d)
+	}
+	return nil
+}
+
+func (rb *XRowBuilder) Build(buf []byte) ([]byte, error) {
+	// Separate null and not-null column IDs.
+	nullIdx := len(rb.tempColIDs) - int(rb.row.numNullCols)
+	notNullIdx := 0
+	if rb.row.large {
+		rb.row.colIDs32 = make([]uint32, len(rb.tempColIDs))
+	} else {
+		rb.row.colIDs = make([]byte, len(rb.tempColIDs))
+	}
+	for i, colID := range rb.tempColIDs {
+		if rb.values[i].IsNull() {
+			if rb.row.large {
+				rb.row.colIDs32[nullIdx] = uint32(colID)
+			} else {
+				rb.row.colIDs[nullIdx] = byte(colID)
+			}
+			nullIdx++
+		} else {
+			if rb.row.large {
+				rb.row.colIDs32[notNullIdx] = uint32(colID)
+			} else {
+				rb.row.colIDs[notNullIdx] = byte(colID)
+			}
+			rb.values[notNullIdx] = rb.values[i]
+			notNullIdx++
+		}
+	}
+	sort.Sort(rb)
+	if rb.row.large {
+		sort.Slice(rb.row.colIDs32[notNullIdx:], func(i, j int) bool {
+			return rb.row.colIDs32[i] < rb.row.colIDs32[j]
+		})
+	} else {
+		sort.Slice(rb.row.colIDs[notNullIdx:], func(i, j int) bool {
+			return rb.row.colIDs[i] < rb.row.colIDs[j]
+		})
+	}
+	for i := 0; i < notNullIdx; i++ {
+		d := rb.values[i]
+		switch d.Kind() {
+		case types.KindInt64:
+			rb.row.valFlags = append(rb.row.valFlags, IntFlag)
+			binVal := encodeInt(d.GetInt64())
+			rb.row.data = append(rb.row.data, binVal...)
+		case types.KindUint64:
+			rb.row.valFlags = append(rb.row.valFlags, UintFlag)
+			binVal := encodeUint(d.GetUint64())
+			rb.row.data = append(rb.row.data, binVal...)
+		case types.KindString, types.KindBytes:
+			rb.row.valFlags = append(rb.row.valFlags, BytesFlag)
+			rb.row.data = append(rb.row.data, d.GetBytes()...)
+		default:
+			var err error
+			rb.tempData, err = codec.EncodeValue(rb.sc, rb.tempData[:0], d)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			rb.row.valFlags = append(rb.row.valFlags, rb.tempData[0])
+			rb.row.data = append(rb.row.data, rb.tempData[1:]...)
+		}
+		rb.row.offsets32 = append(rb.row.offsets32, uint32(len(rb.row.data)))
+		if len(rb.row.data) > math.MaxUint16 && !rb.row.large {
+			rb.row.colIDs32 = make([]uint32, notNullIdx)
+			rb.row.offsets32 = make([]uint32, notNullIdx)
+			for i := 0; i < notNullIdx; i++ {
+				rb.row.colIDs32[i] = uint32(rb.row.colIDs[i])
+				rb.row.offsets32[i] = uint32(rb.row.offsets[i])
+			}
+			rb.row.large = true
+		}
+		if rb.row.large {
+			rb.row.offsets32 = append(rb.row.offsets32, uint32(len(rb.row.data)))
+		} else {
+			rb.row.offsets = append(rb.row.offsets, uint16(len(rb.row.data)))
+		}
+	}
+	if !rb.row.large {
+		if len(rb.row.data) >= math.MaxUint16 {
+			rb.row.large = true
+			rb.row.colIDs32 = make([]uint32, len(rb.row.colIDs))
+			for i, val := range rb.row.colIDs {
+				rb.row.colIDs32[i] = uint32(val)
+			}
+		} else {
+			rb.row.offsets = make([]uint16, len(rb.row.offsets32))
+			for i, val := range rb.row.offsets32 {
+				rb.row.offsets[i] = uint16(val)
+			}
+		}
+	}
+	buf = append(buf, CodecVer)
+	flag := byte(0)
+	if rb.row.large {
+		flag = 1
+	}
+	buf = append(buf, flag)
+	buf = append(buf, byte(rb.row.numNotNullCols), byte(rb.row.numNotNullCols>>8))
+	buf = append(buf, byte(rb.row.numNullCols), byte(rb.row.numNullCols>>8))
+	buf = append(buf, rb.row.valFlags...)
+	if rb.row.large {
+		buf = append(buf, u32SliceToBytes(rb.row.colIDs32)...)
+		buf = append(buf, u32SliceToBytes(rb.row.offsets32)...)
+	} else {
+		buf = append(buf, rb.row.colIDs...)
+		buf = append(buf, u16SliceToBytes(rb.row.offsets)...)
+	}
+	buf = append(buf, rb.row.data...)
+	return buf, nil
+}
+
+func (rb *XRowBuilder) Less(i, j int) bool {
+	if rb.row.large {
+		return rb.row.colIDs32[i] < rb.row.colIDs32[j]
+	}
+	return rb.row.colIDs[i] < rb.row.colIDs[j]
+}
+
+func (rb *XRowBuilder) Len() int {
+	return len(rb.tempColIDs) - int(rb.row.numNullCols)
+}
+
+func (rb *XRowBuilder) Swap(i, j int) {
+	if rb.row.large {
+		rb.row.colIDs32[i], rb.row.colIDs32[j] = rb.row.colIDs32[j], rb.row.colIDs32[i]
+	} else {
+		rb.row.colIDs[i], rb.row.colIDs[j] = rb.row.colIDs[j], rb.row.colIDs[i]
+	}
+	rb.values[i], rb.values[j] = rb.values[j], rb.values[i]
+}
+
+var defaultStmtCtx = &stmtctx.StatementContext{
+	TimeZone: time.Local,
+}
+
+const (
+	rowKeyLen       = 19
+	recordPrefixIdx = 10
+)
+
+func IsRowKey(key []byte) bool {
+	return len(key) == rowKeyLen && key[0] == 't' && key[recordPrefixIdx] == 'r'
+}
+
+// OldRowToXRow converts old row to new row.
+func OldRowToXRow(oldRow, buf []byte) ([]byte, error) {
+	var builder XRowBuilder
+	builder.sc = defaultStmtCtx
+	err := builder.SetOldRow(oldRow)
+	if err != nil {
+		return nil, err
+	}
+	return builder.Build(buf[:0])
+}
+
+// XRowToOldRow converts new row to old row.
+func XRowToOldRow(rowData, buf []byte) ([]byte, error) {
+	if len(rowData) == 0 {
+		return rowData, nil
+	}
+	buf = buf[:0]
+	var r XRow
+	err := r.setRowData(rowData)
+	if err != nil {
+		return nil, err
+	}
+	for i, colID := range r.colIDs {
+		buf = append(buf, VarintFlag)
+		buf = codec.EncodeVarint(buf, int64(colID))
+		if i < int(r.numNotNullCols) {
+			val := r.getData(i)
+			switch r.valFlags[i] {
+			case BytesFlag:
+				buf = append(buf, CompactBytesFlag)
+				buf = codec.EncodeCompactBytes(buf, val)
+			case IntFlag:
+				buf = append(buf, IntFlag)
+				buf = codec.EncodeInt(buf, decodeInt(val))
+			case UintFlag:
+				buf = append(buf, UintFlag)
+				buf = codec.EncodeUint(buf, decodeUint(val))
+			default:
+				buf = append(buf, r.valFlags[i])
+				buf = append(buf, val...)
+			}
+		} else {
+			buf = append(buf, NilFlag)
+		}
+	}
+	if len(buf) == 0 {
+		buf = append(buf, NilFlag)
+	}
+	return buf, nil
+}

--- a/rowcodec/rowcodec_test.go
+++ b/rowcodec/rowcodec_test.go
@@ -1,0 +1,47 @@
+package rowcodec
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testSuite{})
+
+type testSuite struct{}
+
+func (s *testSuite) TestRowCodec(c *C) {
+	colIDs := []int64{1, 2, 3}
+	tps := make([]*types.FieldType, 3)
+	for i := 0; i < 3; i++ {
+		tps[i] = types.NewFieldType(mysql.TypeLonglong)
+	}
+	sc := new(stmtctx.StatementContext)
+	oldRow, err := tablecodec.EncodeRow(sc, types.MakeDatums(1, 2, 3), colIDs, nil, nil)
+	c.Check(err, IsNil)
+
+	rb := new(XRowBuilder)
+	rb.SetOldRow(oldRow)
+
+	newRow, err := rb.Build(nil)
+	c.Check(err, IsNil)
+	rd, err := NewXRowDecoder(colIDs, 0, tps, make([][]byte, 3), time.Local)
+	c.Assert(err, IsNil)
+	chk := chunk.NewChunkWithCapacity(tps, 1)
+	err = rd.Decode(newRow, -1, chk)
+	c.Assert(err, IsNil)
+	row := chk.GetRow(0)
+	for i := 0; i < 3; i++ {
+		c.Assert(row.GetInt64(i), Equals, int64(i)+1)
+	}
+}

--- a/tikv/executor.go
+++ b/tikv/executor.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/ngaut/faketikv/rowcodec"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
@@ -726,7 +727,11 @@ func hasColVal(data [][]byte, colIDs map[int64]int, id int64) bool {
 
 // getRowData decodes raw byte slice to row data.
 func getRowData(columns []*tipb.ColumnInfo, colIDs map[int64]int, handle int64, value []byte) ([][]byte, error) {
-	values, err := tablecodec.CutRowNew(value, colIDs)
+	oldRow, err := rowcodec.XRowToOldRow(value, nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	values, err := tablecodec.CutRowNew(oldRow, colIDs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
- The old row is converted to the new format in `Prewrite`.
- The new row is converted to the old format if closure executor is not supported for Coprocessor request.
- The new row is converted to the old format in `Scan`, `Get` and `BatchGet`.