### PR TITLE
optimize and refactor encoding and add benchmark

### DIFF
--- a/rowcodec/encoder.go
+++ b/rowcodec/encoder.go
@@ -11,170 +11,287 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 )
 
-// XRowBuilder is used to build new row from an old row.
-type XRowBuilder struct {
-	row        XRow
-	sc         *stmtctx.StatementContext
+// Encoder is used to encode a row.
+type Encoder struct {
+	row
 	tempColIDs []int64
 	values     []types.Datum
 	tempData   []byte
 }
 
-func (rb *XRowBuilder) SetOldRow(oldRow []byte) error {
+func (encoder *Encoder) reset() {
+	encoder.large = false
+	encoder.numNotNullCols = 0
+	encoder.numNullCols = 0
+	encoder.data = encoder.data[:0]
+	encoder.tempColIDs = encoder.tempColIDs[:0]
+	encoder.values = encoder.values[:0]
+}
+
+func (encoder *Encoder) addColumn(colID int64, d types.Datum) {
+	if colID > 255 {
+		encoder.large = true
+	}
+	if d.IsNull() {
+		encoder.numNullCols++
+	} else {
+		encoder.numNotNullCols++
+	}
+	encoder.tempColIDs = append(encoder.tempColIDs, colID)
+	encoder.values = append(encoder.values, d)
+}
+
+// Encode encodes a row from a datums slice.
+func (encoder *Encoder) Encode(colIDs []int64, values []types.Datum, buf []byte) ([]byte, error) {
+	encoder.reset()
+	for i, colID := range colIDs {
+		encoder.addColumn(colID, values[i])
+	}
+	return encoder.build(buf[:0])
+}
+
+// EncodeFromOldRow encodes a row from an old-format row.
+func (encoder *Encoder) EncodeFromOldRow(oldRow, buf []byte) ([]byte, error) {
+	encoder.reset()
 	for len(oldRow) > 1 {
 		var d types.Datum
 		var err error
 		oldRow, d, err = codec.DecodeOne(oldRow)
 		if err != nil {
-			return errors.Trace(err)
+			return nil, err
 		}
 		colID := d.GetInt64()
 		oldRow, d, err = codec.DecodeOne(oldRow)
 		if err != nil {
-			return errors.Trace(err)
+			return nil, err
 		}
-		if colID > 255 {
-			rb.row.large = true
-		}
-		if d.IsNull() {
-			rb.row.numNullCols++
-		} else {
-			rb.row.numNotNullCols++
-		}
-		rb.tempColIDs = append(rb.tempColIDs, colID)
-		rb.values = append(rb.values, d)
+		encoder.addColumn(colID, d)
 	}
-	return nil
+	return encoder.build(buf[:0])
 }
 
-func (rb *XRowBuilder) Build(buf []byte) ([]byte, error) {
+func (encoder *Encoder) build(buf []byte) ([]byte, error) {
+	r := &encoder.row
 	// Separate null and not-null column IDs.
-	nullIdx := len(rb.tempColIDs) - int(rb.row.numNullCols)
+	numCols := len(encoder.tempColIDs)
+	nullIdx := numCols - int(r.numNullCols)
 	notNullIdx := 0
-	if rb.row.large {
-		rb.row.colIDs32 = make([]uint32, len(rb.tempColIDs))
+	if r.large {
+		encoder.initColIDs32()
+		encoder.initOffsets32()
 	} else {
-		rb.row.colIDs = make([]byte, len(rb.tempColIDs))
+		encoder.initColIDs()
+		encoder.initOffsets()
 	}
-	for i, colID := range rb.tempColIDs {
-		if rb.values[i].IsNull() {
-			if rb.row.large {
-				rb.row.colIDs32[nullIdx] = uint32(colID)
+	for i, colID := range encoder.tempColIDs {
+		if encoder.values[i].IsNull() {
+			if r.large {
+				r.colIDs32[nullIdx] = uint32(colID)
 			} else {
-				rb.row.colIDs[nullIdx] = byte(colID)
+				r.colIDs[nullIdx] = byte(colID)
 			}
 			nullIdx++
 		} else {
-			if rb.row.large {
-				rb.row.colIDs32[notNullIdx] = uint32(colID)
+			if r.large {
+				r.colIDs32[notNullIdx] = uint32(colID)
 			} else {
-				rb.row.colIDs[notNullIdx] = byte(colID)
+				r.colIDs[notNullIdx] = byte(colID)
 			}
-			rb.values[notNullIdx] = rb.values[i]
+			encoder.values[notNullIdx] = encoder.values[i]
 			notNullIdx++
 		}
 	}
-	sort.Sort(rb)
-	if rb.row.large {
-		sort.Slice(rb.row.colIDs32[notNullIdx:], func(i, j int) bool {
-			return rb.row.colIDs32[i] < rb.row.colIDs32[j]
-		})
+	if r.large {
+		largeNotNullSorter := (*largeNotNullSorter)(encoder)
+		sort.Sort(largeNotNullSorter)
+		if r.numNullCols > 0 {
+			largeNullSorter := (*largeNullSorter)(encoder)
+			sort.Sort(largeNullSorter)
+		}
 	} else {
-		sort.Slice(rb.row.colIDs[notNullIdx:], func(i, j int) bool {
-			return rb.row.colIDs[i] < rb.row.colIDs[j]
-		})
+		smallNotNullSorter := (*smallNotNullSorter)(encoder)
+		sort.Sort(smallNotNullSorter)
+		if r.numNullCols > 0 {
+			smallNullSorter := (*smallNullSorter)(encoder)
+			sort.Sort(smallNullSorter)
+		}
 	}
+	encoder.initValFlags()
 	for i := 0; i < notNullIdx; i++ {
-		d := rb.values[i]
+		d := encoder.values[i]
 		switch d.Kind() {
 		case types.KindInt64:
-			rb.row.valFlags = append(rb.row.valFlags, IntFlag)
-			binVal := encodeInt(d.GetInt64())
-			rb.row.data = append(rb.row.data, binVal...)
+			r.valFlags[i] = IntFlag
+			r.data = encodeInt(r.data, d.GetInt64())
 		case types.KindUint64:
-			rb.row.valFlags = append(rb.row.valFlags, UintFlag)
-			binVal := encodeUint(d.GetUint64())
-			rb.row.data = append(rb.row.data, binVal...)
+			r.valFlags[i] = UintFlag
+			r.data = encodeUint(r.data, d.GetUint64())
 		case types.KindString, types.KindBytes:
-			rb.row.valFlags = append(rb.row.valFlags, BytesFlag)
-			rb.row.data = append(rb.row.data, d.GetBytes()...)
+			r.valFlags[i] = BytesFlag
+			r.data = append(r.data, d.GetBytes()...)
 		default:
 			var err error
-			rb.tempData, err = codec.EncodeValue(rb.sc, rb.tempData[:0], d)
+			encoder.tempData, err = codec.EncodeValue(defaultStmtCtx, encoder.tempData[:0], d)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			rb.row.valFlags = append(rb.row.valFlags, rb.tempData[0])
-			rb.row.data = append(rb.row.data, rb.tempData[1:]...)
+			r.valFlags[i] = encoder.tempData[0]
+			r.data = append(r.data, encoder.tempData[1:]...)
 		}
-		rb.row.offsets32 = append(rb.row.offsets32, uint32(len(rb.row.data)))
-		if len(rb.row.data) > math.MaxUint16 && !rb.row.large {
-			rb.row.colIDs32 = make([]uint32, notNullIdx)
-			rb.row.offsets32 = make([]uint32, notNullIdx)
-			for i := 0; i < notNullIdx; i++ {
-				rb.row.colIDs32[i] = uint32(rb.row.colIDs[i])
-				rb.row.offsets32[i] = uint32(rb.row.offsets[i])
+		if len(r.data) > math.MaxUint16 && !r.large {
+			// We need to convert the row to large row.
+			encoder.initColIDs32()
+			for j := 0; j <= numCols; j++ {
+				r.colIDs32[j] = uint32(r.colIDs[j])
 			}
-			rb.row.large = true
+			encoder.initOffsets32()
+			for j := 0; j <= i; j++ {
+				r.offsets32[j] = uint32(r.offsets[j])
+			}
+			r.large = true
 		}
-		if rb.row.large {
-			rb.row.offsets32 = append(rb.row.offsets32, uint32(len(rb.row.data)))
+		if r.large {
+			r.offsets32[i] = uint32(len(r.data))
 		} else {
-			rb.row.offsets = append(rb.row.offsets, uint16(len(rb.row.data)))
+			r.offsets[i] = uint16(len(r.data))
 		}
 	}
-	if !rb.row.large {
-		if len(rb.row.data) >= math.MaxUint16 {
-			rb.row.large = true
-			rb.row.colIDs32 = make([]uint32, len(rb.row.colIDs))
-			for i, val := range rb.row.colIDs {
-				rb.row.colIDs32[i] = uint32(val)
+	if !r.large {
+		if len(r.data) >= math.MaxUint16 {
+			r.large = true
+			encoder.initColIDs32()
+			for i, val := range r.colIDs {
+				r.colIDs32[i] = uint32(val)
 			}
 		} else {
-			rb.row.offsets = make([]uint16, len(rb.row.offsets32))
-			for i, val := range rb.row.offsets32 {
-				rb.row.offsets[i] = uint16(val)
+			encoder.initOffsets()
+			for i, val := range r.offsets32 {
+				r.offsets[i] = uint16(val)
 			}
 		}
 	}
 	buf = append(buf, CodecVer)
 	flag := byte(0)
-	if rb.row.large {
+	if r.large {
 		flag = 1
 	}
 	buf = append(buf, flag)
-	buf = append(buf, byte(rb.row.numNotNullCols), byte(rb.row.numNotNullCols>>8))
-	buf = append(buf, byte(rb.row.numNullCols), byte(rb.row.numNullCols>>8))
-	buf = append(buf, rb.row.valFlags...)
-	if rb.row.large {
-		buf = append(buf, u32SliceToBytes(rb.row.colIDs32)...)
-		buf = append(buf, u32SliceToBytes(rb.row.offsets32)...)
+	buf = append(buf, byte(r.numNotNullCols), byte(r.numNotNullCols>>8))
+	buf = append(buf, byte(r.numNullCols), byte(r.numNullCols>>8))
+	buf = append(buf, r.valFlags...)
+	if r.large {
+		buf = append(buf, u32SliceToBytes(r.colIDs32)...)
+		buf = append(buf, u32SliceToBytes(r.offsets32)...)
 	} else {
-		buf = append(buf, rb.row.colIDs...)
-		buf = append(buf, u16SliceToBytes(rb.row.offsets)...)
+		buf = append(buf, r.colIDs...)
+		buf = append(buf, u16SliceToBytes(r.offsets)...)
 	}
-	buf = append(buf, rb.row.data...)
+	buf = append(buf, r.data...)
 	return buf, nil
 }
 
-func (rb *XRowBuilder) Less(i, j int) bool {
-	if rb.row.large {
-		return rb.row.colIDs32[i] < rb.row.colIDs32[j]
-	}
-	return rb.row.colIDs[i] < rb.row.colIDs[j]
-}
-
-func (rb *XRowBuilder) Len() int {
-	return len(rb.tempColIDs) - int(rb.row.numNullCols)
-}
-
-func (rb *XRowBuilder) Swap(i, j int) {
-	if rb.row.large {
-		rb.row.colIDs32[i], rb.row.colIDs32[j] = rb.row.colIDs32[j], rb.row.colIDs32[i]
+func (encoder *Encoder) initValFlags() {
+	if cap(encoder.valFlags) >= int(encoder.numNotNullCols) {
+		encoder.valFlags = encoder.valFlags[:encoder.numNotNullCols]
 	} else {
-		rb.row.colIDs[i], rb.row.colIDs[j] = rb.row.colIDs[j], rb.row.colIDs[i]
+		encoder.valFlags = make([]byte, encoder.numNotNullCols)
 	}
-	rb.values[i], rb.values[j] = rb.values[j], rb.values[i]
+}
+
+func (encoder *Encoder) initColIDs() {
+	numCols := int(encoder.numNotNullCols + encoder.numNullCols)
+	if cap(encoder.colIDs) >= numCols {
+		encoder.colIDs = encoder.colIDs[:numCols]
+	} else {
+		encoder.colIDs = make([]byte, numCols)
+	}
+}
+
+func (encoder *Encoder) initColIDs32() {
+	numCols := int(encoder.numNotNullCols + encoder.numNullCols)
+	if cap(encoder.colIDs32) >= numCols {
+		encoder.colIDs32 = encoder.colIDs32[:numCols]
+	} else {
+		encoder.colIDs32 = make([]uint32, numCols)
+	}
+}
+
+func (encoder *Encoder) initOffsets() {
+	if cap(encoder.offsets) >= int(encoder.numNotNullCols) {
+		encoder.offsets = encoder.offsets[:encoder.numNotNullCols]
+	} else {
+		encoder.offsets = make([]uint16, encoder.numNotNullCols)
+	}
+}
+
+func (encoder *Encoder) initOffsets32() {
+	if cap(encoder.offsets32) >= int(encoder.numNotNullCols) {
+		encoder.offsets32 = encoder.offsets32[:encoder.numNotNullCols]
+	} else {
+		encoder.offsets32 = make([]uint32, encoder.numNotNullCols)
+	}
+}
+
+type largeNotNullSorter Encoder
+
+func (s *largeNotNullSorter) Less(i, j int) bool {
+	return s.colIDs32[i] < s.colIDs32[j]
+}
+
+func (s *largeNotNullSorter) Len() int {
+	return int(s.numNotNullCols)
+}
+
+func (s *largeNotNullSorter) Swap(i, j int) {
+	s.colIDs32[i], s.colIDs32[j] = s.colIDs32[j], s.colIDs32[i]
+	s.values[i], s.values[j] = s.values[j], s.values[i]
+}
+
+type smallNotNullSorter Encoder
+
+func (s *smallNotNullSorter) Less(i, j int) bool {
+	return s.colIDs[i] < s.colIDs[j]
+}
+
+func (s *smallNotNullSorter) Len() int {
+	return int(s.numNotNullCols)
+}
+
+func (s *smallNotNullSorter) Swap(i, j int) {
+	s.colIDs[i], s.colIDs[j] = s.colIDs[j], s.colIDs[i]
+	s.values[i], s.values[j] = s.values[j], s.values[i]
+}
+
+type smallNullSorter Encoder
+
+func (s *smallNullSorter) Less(i, j int) bool {
+	nullCols := s.colIDs[s.numNotNullCols:]
+	return nullCols[i] < nullCols[j]
+}
+
+func (s *smallNullSorter) Len() int {
+	return int(s.numNullCols)
+}
+
+func (s *smallNullSorter) Swap(i, j int) {
+	nullCols := s.colIDs[s.numNotNullCols:]
+	nullCols[i], nullCols[j] = nullCols[j], nullCols[i]
+}
+
+type largeNullSorter Encoder
+
+func (s *largeNullSorter) Less(i, j int) bool {
+	nullCols := s.colIDs32[s.numNotNullCols:]
+	return nullCols[i] < nullCols[j]
+}
+
+func (s *largeNullSorter) Len() int {
+	return int(s.numNullCols)
+}
+
+func (s *largeNullSorter) Swap(i, j int) {
+	nullCols := s.colIDs32[s.numNotNullCols:]
+	nullCols[i], nullCols[j] = nullCols[j], nullCols[i]
 }
 
 var defaultStmtCtx = &stmtctx.StatementContext{
@@ -190,24 +307,13 @@ func IsRowKey(key []byte) bool {
 	return len(key) == rowKeyLen && key[0] == 't' && key[recordPrefixIdx] == 'r'
 }
 
-// OldRowToXRow converts old row to new row.
-func OldRowToXRow(oldRow, buf []byte) ([]byte, error) {
-	var builder XRowBuilder
-	builder.sc = defaultStmtCtx
-	err := builder.SetOldRow(oldRow)
-	if err != nil {
-		return nil, err
-	}
-	return builder.Build(buf[:0])
-}
-
-// XRowToOldRow converts new row to old row.
-func XRowToOldRow(rowData, buf []byte) ([]byte, error) {
+// RowToOldRow converts a row to old-format row.
+func RowToOldRow(rowData, buf []byte) ([]byte, error) {
 	if len(rowData) == 0 {
 		return rowData, nil
 	}
 	buf = buf[:0]
-	var r XRow
+	var r row
 	err := r.setRowData(rowData)
 	if err != nil {
 		return nil, err

--- a/tikv/closure_exec.go
+++ b/tikv/closure_exec.go
@@ -190,7 +190,7 @@ type scanCtx struct {
 	limit   int
 	chk     *chunk.Chunk
 	desc    bool
-	decoder *rowcodec.XRowDecoder
+	decoder *rowcodec.Decoder
 }
 
 type idxScanCtx struct {

--- a/tikv/cop_handler.go
+++ b/tikv/cop_handler.go
@@ -376,7 +376,7 @@ func (e *evalContext) setColumnInfo(cols []*tipb.ColumnInfo) {
 	}
 }
 
-func (e *evalContext) newRowDecoder() (*rowcodec.XRowDecoder, error) {
+func (e *evalContext) newRowDecoder() (*rowcodec.Decoder, error) {
 	colIDs := make([]int64, len(e.columnInfos))
 	defaultVals := make([][]byte, len(e.columnInfos))
 	var handleColID int64
@@ -387,7 +387,7 @@ func (e *evalContext) newRowDecoder() (*rowcodec.XRowDecoder, error) {
 			handleColID = colInfo.ColumnId
 		}
 	}
-	return rowcodec.NewXRowDecoder(colIDs, handleColID, e.fieldTps, defaultVals, e.sc.TimeZone)
+	return rowcodec.NewDecoder(colIDs, handleColID, e.fieldTps, defaultVals, e.sc.TimeZone)
 }
 
 // decodeRelatedColumnVals decodes data to Datum slice according to the row information.

--- a/tikv/server.go
+++ b/tikv/server.go
@@ -167,8 +167,7 @@ func (svr *Server) KvGet(ctx context.Context, req *kvrpcpb.GetRequest) (*kvrpcpb
 		}, nil
 	}
 	if rowcodec.IsRowKey(req.Key) {
-		log.Errorf("kv get key:%x val:%v", req.Key, val)
-		val, err = rowcodec.XRowToOldRow(val, nil)
+		val, err = rowcodec.RowToOldRow(val, nil)
 	}
 	return &kvrpcpb.GetResponse{
 		Value: val,
@@ -197,7 +196,7 @@ func (svr *Server) KvScan(ctx context.Context, req *kvrpcpb.ScanRequest) (*kvrpc
 	var buf []byte
 	var scanFunc ScanFunc = func(key, value []byte) error {
 		if rowcodec.IsRowKey(key) {
-			buf, err = rowcodec.XRowToOldRow(value, buf)
+			buf, err = rowcodec.RowToOldRow(value, buf)
 			if err != nil {
 				return err
 			}
@@ -294,7 +293,7 @@ func (svr *Server) KvBatchGet(ctx context.Context, req *kvrpcpb.BatchGetRequest)
 	batchGetFunc := func(key, value []byte, err error) {
 		if len(value) != 0 {
 			if rowcodec.IsRowKey(key) && err == nil {
-				buf, err = rowcodec.XRowToOldRow(value, buf)
+				buf, err = rowcodec.RowToOldRow(value, buf)
 				value = buf
 			}
 			pairs = append(pairs, &kvrpcpb.KvPair{


### PR DESCRIPTION
Benchmark result for 3 column row (int, string, float):

Encode:
10000000	       114 ns/op	       0 B/op	       0 allocs/op

EncodeFromOldRow:
10000000	       257 ns/op	       0 B/op	       0 allocs/op

Decode:
20000000	        65.9 ns/op	       0 B/op	       0 allocs/op


The `EncodeFromOldRow` is currently used, it first decodes from an old row, then encodes to a new row. When we encode row in TiDB, `Encode` will be used.
